### PR TITLE
Add dsh-qq2006: QQ2006 skin plugin for the DSH Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ No entries yet. [Submit the first plugin.](CONTRIBUTING.md)
 
 - [dsh-cc-tui](https://github.com/ccch1mneyyy/dsh-cc-tui) — A Claude Code-style full-screen terminal interface with streaming thought display, rollback controls, and context/TPS indicators.
 
+- [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — A switchable QQ2006 skin for the DeepSeek Harness Web UI with a coral-blue theme and retro assets.
+
 - [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — A shared sticker catalog serving the Web UI picker, a /sticker command, and an agent send_sticker tool, with two character variants and workflow-reaction stickers.
 
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) — A hand-drawn pixel whale companion for the DSH Web UI that reacts to agent activity.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -259,6 +259,15 @@
         "en": "Helps agents connect to databases and write SQL for data tasks.",
         "zh-CN": "帮助智能体连接数据库并编写 SQL 以完成数据任务。"
       }
+    },
+    {
+      "name": "dsh-qq2006",
+      "url": "https://github.com/LaplaceYoung/dsh-qq2006",
+      "category": "ai-design-media",
+      "description": {
+        "en": "A switchable QQ2006 skin for the DeepSeek Harness Web UI with a coral-blue theme and retro assets.",
+        "zh-CN": "DeepSeek Harness Web UI 的可切换 QQ2006 皮肤，提供珊瑚蓝主题和复古素材。"
+      }
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -92,6 +92,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-cc-tui](https://github.com/ccch1mneyyy/dsh-cc-tui) — Claude Code 风格的全屏终端界面，提供流式思考展示、回滚控制及上下文/TPS 指示器。
 
+- [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — DeepSeek Harness Web UI 的可切换 QQ2006 皮肤，提供珊瑚蓝主题和复古素材。
+
 - [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — 同一份表情包 catalog 同时服务 Web UI 选择器、/sticker 命令和智能体 send_sticker 工具，提供双角色变体与工作流反应表情。
 
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) — 为 DSH Web UI 提供会随智能体活动作出反应的手绘像素鲸鱼伙伴。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

dsh-qq2006 turns the DeepSeek Harness Web UI into a switchable QQ2006-style skin. It registers a coral-blue theme through the DSH client theme service (persisted via the theme service's own storage), mirrors the active skin onto `body[data-ds-skin]` for component-level patches, and ships the global stylesheet plus the original QQ2006 asset set (assets from mengkunsoft/QQ2006, study/learning use only, attribution in `assets/qq2006/README.txt`).

Repo: https://github.com/LaplaceYoung/dsh-qq2006