### PR TITLE
fix: update context-doctor link + enrich description

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 ### Data, research & knowledge
 
-- [context-doctor](https://github.com/dsh-external/context-doctor) — Audits the token cost of instruction chains, skill catalogs, and tool schemas, and detects duplication and conflicts.
+- [context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) — See exactly what every request carries: token cost of the AGENTS.md chain, skill catalog and tool schemas, with duplicate/conflict detection and actionable pruning tips (Web UI gauge + context_audit tool, read-only).
 
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) — Lets DeepSeek Harness cite relevant conversation history from Codex and Claude Code.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -3,35 +3,59 @@
   "categories": [
     {
       "id": "developer-tools",
-      "title": { "en": "Developer tools", "zh-CN": "开发工具" }
+      "title": {
+        "en": "Developer tools",
+        "zh-CN": "开发工具"
+      }
     },
     {
       "id": "agent-automation",
-      "title": { "en": "Agent orchestration & automation", "zh-CN": "智能体编排与自动化" }
+      "title": {
+        "en": "Agent orchestration & automation",
+        "zh-CN": "智能体编排与自动化"
+      }
     },
     {
       "id": "productivity-collaboration",
-      "title": { "en": "Productivity & collaboration", "zh-CN": "效率与协作" }
+      "title": {
+        "en": "Productivity & collaboration",
+        "zh-CN": "效率与协作"
+      }
     },
     {
       "id": "data-research-knowledge",
-      "title": { "en": "Data, research & knowledge", "zh-CN": "数据、研究与知识" }
+      "title": {
+        "en": "Data, research & knowledge",
+        "zh-CN": "数据、研究与知识"
+      }
     },
     {
       "id": "cloud-devops-observability",
-      "title": { "en": "Cloud, DevOps & observability", "zh-CN": "云、DevOps 与可观测性" }
+      "title": {
+        "en": "Cloud, DevOps & observability",
+        "zh-CN": "云、DevOps 与可观测性"
+      }
     },
     {
       "id": "ai-design-media",
-      "title": { "en": "AI, design & media", "zh-CN": "AI、设计与媒体" }
+      "title": {
+        "en": "AI, design & media",
+        "zh-CN": "AI、设计与媒体"
+      }
     },
     {
       "id": "business-finance-commerce",
-      "title": { "en": "Business, finance & commerce", "zh-CN": "商业、金融与电商" }
+      "title": {
+        "en": "Business, finance & commerce",
+        "zh-CN": "商业、金融与电商"
+      }
     },
     {
       "id": "life-devices-physical-world",
-      "title": { "en": "Life, devices & the physical world", "zh-CN": "生活、设备与物理世界" }
+      "title": {
+        "en": "Life, devices & the physical world",
+        "zh-CN": "生活、设备与物理世界"
+      }
     }
   ],
   "plugins": [
@@ -352,11 +376,11 @@
     },
     {
       "name": "context-doctor",
-      "url": "https://github.com/dsh-external/context-doctor",
+      "url": "https://github.com/Zhenyu98/dsh-context-doctor",
       "category": "data-research-knowledge",
       "description": {
-        "en": "Audits the token cost of instruction chains, skill catalogs, and tool schemas, and detects duplication and conflicts.",
-        "zh-CN": "审计指令链、技能目录和工具 schema 的 token 成本，并检测重复与冲突。"
+        "en": "See exactly what every request carries: token cost of the AGENTS.md chain, skill catalog and tool schemas, with duplicate/conflict detection and actionable pruning tips (Web UI gauge + context_audit tool, read-only).",
+        "zh-CN": "看清模型每个请求到底背着多少上下文：指令链/技能目录/工具 schema 的 token 成本逐项量化，自动检测重复与冲突，给出可执行裁剪建议（Web 圆环面板 + context_audit 工具，全程只读）。"
       }
     },
     {

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -94,7 +94,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 ### 数据、研究与知识
 
-- [context-doctor](https://github.com/dsh-external/context-doctor) — 审计指令链、技能目录和工具 schema 的 token 成本，并检测重复与冲突。
+- [context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) — 看清模型每个请求到底背着多少上下文：指令链/技能目录/工具 schema 的 token 成本逐项量化，自动检测重复与冲突，给出可执行裁剪建议（Web 圆环面板 + context_audit 工具，全程只读）。
 
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) — 让 DeepSeek Harness 引用 Codex 与 Claude Code 中相关的历史对话。
 


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

context-doctor 插件已从 dsh-external 组织转移到个人账号 Zhenyu98 并公开（仓库随后更名为 `dsh-context-doctor`）。本次更新：

1. **链接**：`dsh-external/context-doctor` → `Zhenyu98/dsh-context-doctor`（canonical public URL）
2. **描述**（en/zh-CN 双语同步丰富）：原描述只提到审计指令链，未覆盖完整能力——token 成本逐项量化（指令链/技能目录/工具 schema）、重复与冲突检测、可执行裁剪建议，以及 Web 圆环面板 + `context_audit` 工具、全程只读

已按 CONTRIBUTING 流程：仅编辑 `catalog/plugins.json`，通过 `generate_readmes.py` 重新生成 README.md 与 docs/README.zh-CN.md，`--check` 校验通过。