### PR TITLE
Add billion-context-dsh to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 <!-- CATALOG:START -->
 ### Developer tools
 
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi — the model decides when and what to compress.
+
 - [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — A sidebar workbench with extensible tabs, file viewing and editing, terminal, Git, and sub-agent tools.
 
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — A send_artifact tool that validates model-produced files and delivers structured descriptors through the standard dsh event stream for any client to render.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -36,6 +36,15 @@
   ],
   "plugins": [
     {
+      "name": "billion-context-dsh",
+      "url": "https://github.com/Tyan66666/billion-context-dsh",
+      "category": "developer-tools",
+      "description": {
+        "en": "Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi — the model decides when and what to compress.",
+        "zh-CN": "面向 DeepSeek Harness 的模型驱动上下文压缩（ACP），移植自 billion-context-pi——由模型决定何时压缩、压缩什么。"
+      }
+    },
+    {
       "name": "mstar-harness",
       "url": "https://github.com/btspoony/mstar-harness",
       "category": "agent-automation",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -38,6 +38,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 <!-- CATALOG:START -->
 ### 开发工具
 
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — 面向 DeepSeek Harness 的模型驱动上下文压缩（ACP），移植自 billion-context-pi——由模型决定何时压缩、压缩什么。
+
 - [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 完整的侧边栏工作台，支持扩展 Tab，并内置文件查看与编辑、终端、Git 和子智能体工具。
 
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — 提供 send_artifact 工具，校验模型产出的文件并通过 dsh 标准事件流交付结构化描述子，任何客户端都可按需呈现。


### PR DESCRIPTION
Add [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) under developer-tools.

Model-driven context compression (Active Context Pruning / ACP) for DeepSeek Harness, ported from billion-context-pi (ranxianglei) — the model decides when and what to compress. CompactionEngine backend with compress / decompress / search_context / acp_status tools and /acp command; published on npm as billion-context-dsh. Bilingual description included; pages regenerated and validated.