### PR TITLE
Add deepseek-harness-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 <!-- CATALOG:START -->
 ### Developer tools
 
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — A Rust terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
+
 - [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — A sidebar workbench with extensible tabs, file viewing and editing, terminal, Git, and sub-agent tools.
 
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — A send_artifact tool that validates model-produced files and delivers structured descriptors through the standard dsh event stream for any client to render.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -423,6 +423,15 @@
       }
     },
     {
+      "name": "deepseek-harness-tui",
+      "url": "https://github.com/openma-ai/deepseek-harness-tui",
+      "category": "developer-tools",
+      "description": {
+        "en": "A Rust terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.",
+        "zh-CN": "Rust 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。"
+      }
+    },
+    {
       "name": "dsh-qq2006",
       "url": "https://github.com/LaplaceYoung/dsh-qq2006",
       "category": "ai-design-media",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -38,6 +38,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 <!-- CATALOG:START -->
 ### 开发工具
 
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — Rust 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载。
+
 - [DSH Better Sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) — 完整的侧边栏工作台，支持扩展 Tab，并内置文件查看与编辑、终端、Git 和子智能体工具。
 
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — 提供 send_artifact 工具，校验模型产出的文件并通过 dsh 标准事件流交付结构化描述子，任何客户端都可按需呈现。


### PR DESCRIPTION
## What changed

Adds `openma-ai/deepseek-harness-tui` to the catalog source and regenerates both language versions.

## Why

The project is a maintained DeepSeek Harness integration: a Rust terminal client that consumes the SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.

## User impact

Readers can discover a terminal-native DSH interface with streamed reasoning, tool events, subagent activity, and durable sessions.

## Checks

- `python scripts/generate_readmes.py`
- `python scripts/generate_readmes.py --check`
- `jq empty catalog/plugins.json`
- `git diff --check`
