### PR TITLE
docs: add dsh-turn-index plugin entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-track](https://github.com/fakechris/dsh-track) — An embedded task-management engine with decision points, an idea-capture wall, and Linear-style issue storage.
 
+- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) — A turn-index sidebar listing every user turn, with click-to-jump navigation and scroll-spy highlighting.
+
 - [dsh-ui-progress](https://github.com/lhh010/dsh-ui-progress) — Shows persistent conversation progress, live token generation speed, interruption state, and todo reminders in the Web UI.
 
 ### Data, research & knowledge

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -430,6 +430,15 @@
         "en": "A switchable QQ2006 skin for the DeepSeek Harness Web UI with a coral-blue theme and retro assets.",
         "zh-CN": "DeepSeek Harness Web UI 的可切换 QQ2006 皮肤，提供珊瑚蓝主题和复古素材。"
       }
+    },
+    {
+      "name": "dsh-turn-index",
+      "url": "https://github.com/Simon314620/dsh-turn-index",
+      "category": "productivity-collaboration",
+      "description": {
+        "en": "A turn-index sidebar listing every user turn, with click-to-jump navigation and scroll-spy highlighting.",
+        "zh-CN": "轮次索引侧边栏：列出每一轮用户提问，点击跳转到对应位置，滚动时自动高亮当前轮次。"
+      }
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -92,6 +92,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-track](https://github.com/fakechris/dsh-track) — 嵌入式任务管理引擎，提供决策点、念头捕获墙和 Linear 风格的 issue 存储。
 
+- [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) — 轮次索引侧边栏：列出每一轮用户提问，点击跳转到对应位置，滚动时自动高亮当前轮次。
+
 - [dsh-ui-progress](https://github.com/lhh010/dsh-ui-progress) — 在 Web UI 中常驻显示会话进度、实时 token 生成速率、中断状态和待办提醒。
 
 ### 数据、研究与知识


### PR DESCRIPTION
Add [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) to the productivity-collaboration category.

- Entry added to catalog/plugins.json with bilingual en/zh-CN descriptions
- READMEs regenerated with scripts/generate_readmes.py (--check passes)
- Community plugin, MIT, npm dsh-turn-index@0.1.0, verified on DSH 0.1.0-rc.6