### PR TITLE
Add dsh-harness-mcp-server (MCP server exposing Harness agent)

### DIFF
--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -3,35 +3,59 @@
   "categories": [
     {
       "id": "developer-tools",
-      "title": { "en": "Developer tools", "zh-CN": "开发工具" }
+      "title": {
+        "en": "Developer tools",
+        "zh-CN": "开发工具"
+      }
     },
     {
       "id": "agent-automation",
-      "title": { "en": "Agent orchestration & automation", "zh-CN": "智能体编排与自动化" }
+      "title": {
+        "en": "Agent orchestration & automation",
+        "zh-CN": "智能体编排与自动化"
+      }
     },
     {
       "id": "productivity-collaboration",
-      "title": { "en": "Productivity & collaboration", "zh-CN": "效率与协作" }
+      "title": {
+        "en": "Productivity & collaboration",
+        "zh-CN": "效率与协作"
+      }
     },
     {
       "id": "data-research-knowledge",
-      "title": { "en": "Data, research & knowledge", "zh-CN": "数据、研究与知识" }
+      "title": {
+        "en": "Data, research & knowledge",
+        "zh-CN": "数据、研究与知识"
+      }
     },
     {
       "id": "cloud-devops-observability",
-      "title": { "en": "Cloud, DevOps & observability", "zh-CN": "云、DevOps 与可观测性" }
+      "title": {
+        "en": "Cloud, DevOps & observability",
+        "zh-CN": "云、DevOps 与可观测性"
+      }
     },
     {
       "id": "ai-design-media",
-      "title": { "en": "AI, design & media", "zh-CN": "AI、设计与媒体" }
+      "title": {
+        "en": "AI, design & media",
+        "zh-CN": "AI、设计与媒体"
+      }
     },
     {
       "id": "business-finance-commerce",
-      "title": { "en": "Business, finance & commerce", "zh-CN": "商业、金融与电商" }
+      "title": {
+        "en": "Business, finance & commerce",
+        "zh-CN": "商业、金融与电商"
+      }
     },
     {
       "id": "life-devices-physical-world",
-      "title": { "en": "Life, devices & the physical world", "zh-CN": "生活、设备与物理世界" }
+      "title": {
+        "en": "Life, devices & the physical world",
+        "zh-CN": "生活、设备与物理世界"
+      }
     }
   ],
   "plugins": [
@@ -429,6 +453,15 @@
       "description": {
         "en": "A switchable QQ2006 skin for the DeepSeek Harness Web UI with a coral-blue theme and retro assets.",
         "zh-CN": "DeepSeek Harness Web UI 的可切换 QQ2006 皮肤，提供珊瑚蓝主题和复古素材。"
+      }
+    },
+    {
+      "name": "dsh-harness-mcp-server",
+      "url": "https://github.com/chushixixin/dsh-harness-mcp-server",
+      "category": "agent-automation",
+      "description": {
+        "en": "Expose DeepSeek Harness agent capabilities as an MCP server, letting any MCP client (e.g. Hermes) drive Harness to execute coding tasks.",
+        "zh-CN": "把 DeepSeek Harness 的 agent 能力暴露为 MCP server，让任意 MCP 客户端（如 Hermes）驱动 Harness 执行编码任务。"
       }
     }
   ]


### PR DESCRIPTION
Add [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) — a Cordis plugin that runs an MCP server *inside* DeepSeek Harness, letting any MCP client (e.g. Hermes) drive Harness to execute coding tasks (brain=client, arms=Harness).

- npm: `@chushixixin/dsh-harness-mcp-server`
- 5 tools: echo / harness_list_tools / agent_run / task_inbox / task_result
- structured results (changes/verification/leftovers), per-cwd session reuse, sandboxed bash
- has `dsh-plugin` topic + `dsh.bundle` manifest