### PR TITLE
Add dsh-skin: Codex-style skin switcher + custom wallpaper for DSH Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — A switchable QQ2006 skin for the DeepSeek Harness Web UI with a coral-blue theme and retro assets.
 
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex-style skin switcher + custom wallpaper for the DSH Web UI: curated --dsw-alias-* palettes, translucent main canvas/sidebar (overrideTokens) with opacity and blur controls.
+
 - [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — A shared sticker catalog serving the Web UI picker, a /sticker command, and an agent send_sticker tool, with two character variants and workflow-reaction stickers.
 
 - [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) — A hand-drawn pixel whale companion for the DSH Web UI that reacts to agent activity.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -3,59 +3,35 @@
   "categories": [
     {
       "id": "developer-tools",
-      "title": {
-        "en": "Developer tools",
-        "zh-CN": "开发工具"
-      }
+      "title": { "en": "Developer tools", "zh-CN": "开发工具" }
     },
     {
       "id": "agent-automation",
-      "title": {
-        "en": "Agent orchestration & automation",
-        "zh-CN": "智能体编排与自动化"
-      }
+      "title": { "en": "Agent orchestration & automation", "zh-CN": "智能体编排与自动化" }
     },
     {
       "id": "productivity-collaboration",
-      "title": {
-        "en": "Productivity & collaboration",
-        "zh-CN": "效率与协作"
-      }
+      "title": { "en": "Productivity & collaboration", "zh-CN": "效率与协作" }
     },
     {
       "id": "data-research-knowledge",
-      "title": {
-        "en": "Data, research & knowledge",
-        "zh-CN": "数据、研究与知识"
-      }
+      "title": { "en": "Data, research & knowledge", "zh-CN": "数据、研究与知识" }
     },
     {
       "id": "cloud-devops-observability",
-      "title": {
-        "en": "Cloud, DevOps & observability",
-        "zh-CN": "云、DevOps 与可观测性"
-      }
+      "title": { "en": "Cloud, DevOps & observability", "zh-CN": "云、DevOps 与可观测性" }
     },
     {
       "id": "ai-design-media",
-      "title": {
-        "en": "AI, design & media",
-        "zh-CN": "AI、设计与媒体"
-      }
+      "title": { "en": "AI, design & media", "zh-CN": "AI、设计与媒体" }
     },
     {
       "id": "business-finance-commerce",
-      "title": {
-        "en": "Business, finance & commerce",
-        "zh-CN": "商业、金融与电商"
-      }
+      "title": { "en": "Business, finance & commerce", "zh-CN": "商业、金融与电商" }
     },
     {
       "id": "life-devices-physical-world",
-      "title": {
-        "en": "Life, devices & the physical world",
-        "zh-CN": "生活、设备与物理世界"
-      }
+      "title": { "en": "Life, devices & the physical world", "zh-CN": "生活、设备与物理世界" }
     }
   ],
   "plugins": [

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -3,35 +3,59 @@
   "categories": [
     {
       "id": "developer-tools",
-      "title": { "en": "Developer tools", "zh-CN": "开发工具" }
+      "title": {
+        "en": "Developer tools",
+        "zh-CN": "开发工具"
+      }
     },
     {
       "id": "agent-automation",
-      "title": { "en": "Agent orchestration & automation", "zh-CN": "智能体编排与自动化" }
+      "title": {
+        "en": "Agent orchestration & automation",
+        "zh-CN": "智能体编排与自动化"
+      }
     },
     {
       "id": "productivity-collaboration",
-      "title": { "en": "Productivity & collaboration", "zh-CN": "效率与协作" }
+      "title": {
+        "en": "Productivity & collaboration",
+        "zh-CN": "效率与协作"
+      }
     },
     {
       "id": "data-research-knowledge",
-      "title": { "en": "Data, research & knowledge", "zh-CN": "数据、研究与知识" }
+      "title": {
+        "en": "Data, research & knowledge",
+        "zh-CN": "数据、研究与知识"
+      }
     },
     {
       "id": "cloud-devops-observability",
-      "title": { "en": "Cloud, DevOps & observability", "zh-CN": "云、DevOps 与可观测性" }
+      "title": {
+        "en": "Cloud, DevOps & observability",
+        "zh-CN": "云、DevOps 与可观测性"
+      }
     },
     {
       "id": "ai-design-media",
-      "title": { "en": "AI, design & media", "zh-CN": "AI、设计与媒体" }
+      "title": {
+        "en": "AI, design & media",
+        "zh-CN": "AI、设计与媒体"
+      }
     },
     {
       "id": "business-finance-commerce",
-      "title": { "en": "Business, finance & commerce", "zh-CN": "商业、金融与电商" }
+      "title": {
+        "en": "Business, finance & commerce",
+        "zh-CN": "商业、金融与电商"
+      }
     },
     {
       "id": "life-devices-physical-world",
-      "title": { "en": "Life, devices & the physical world", "zh-CN": "生活、设备与物理世界" }
+      "title": {
+        "en": "Life, devices & the physical world",
+        "zh-CN": "生活、设备与物理世界"
+      }
     }
   ],
   "plugins": [
@@ -429,6 +453,15 @@
       "description": {
         "en": "A switchable QQ2006 skin for the DeepSeek Harness Web UI with a coral-blue theme and retro assets.",
         "zh-CN": "DeepSeek Harness Web UI 的可切换 QQ2006 皮肤，提供珊瑚蓝主题和复古素材。"
+      }
+    },
+    {
+      "name": "dsh-skin",
+      "url": "https://github.com/KinGao294/dsh-skin",
+      "category": "ai-design-media",
+      "description": {
+        "en": "Codex-style skin switcher + custom wallpaper for the DSH Web UI: curated --dsw-alias-* palettes, translucent main canvas/sidebar (overrideTokens) with opacity and blur controls.",
+        "zh-CN": "Codex 风格换肤 + 自定义背景插件：内置多套 --dsw-alias-* 配色，主画布/侧边栏半透明壁纸（overrideTokens），支持透明度与模糊调节。"
       }
     }
   ]

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -126,6 +126,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-qq2006](https://github.com/LaplaceYoung/dsh-qq2006) — DeepSeek Harness Web UI 的可切换 QQ2006 皮肤，提供珊瑚蓝主题和复古素材。
 
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) — Codex 风格换肤 + 自定义背景插件：内置多套 --dsw-alias-* 配色，主画布/侧边栏半透明壁纸（overrideTokens），支持透明度与模糊调节。
+
 - [dsh-stickers](https://github.com/william-jin-cmu/dsh-stickers) — 同一份表情包 catalog 同时服务 Web UI 选择器、/sticker 命令和智能体 send_sticker 工具，提供双角色变体与工作流反应表情。
 
 - [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) — 为 DSH Web UI 提供会随智能体活动作出反应的手绘像素鲸鱼伙伴。


### PR DESCRIPTION
## What

Add [dsh-skin](https://github.com/KinGao294/dsh-skin) to `catalog/plugins.json` (category: ai-design-media) and regenerated both language README pages.

## Why

dsh-skin brings Codex-style theming to the DSH Web UI:

- 7 curated `--dsw-alias-*` palettes, one-click switching from Settings → General;
- custom wallpaper: fixed backdrop layer + translucent main canvas/sidebar via `ctx.theme.overrideTokens`, with opacity and blur sliders;
- localStorage persistence, installable via `dsh plugin --profile web add -w dsh-skin`.

Generated pages verified with `python3 scripts/generate_readmes.py --check`.