### PR TITLE
Add dsh-balance-meter to developer-tools catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) — Embeds isolated web page previews in DSH Web for element annotations and visual adjustments that guide source edits.
 
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.
+
 - [plugin-registry](https://github.com/vlln/plugin-registry) — A browser-based plugin management console with official guidance for creating DSH plugins.
 
 - [Prompt Studio](https://github.com/Moeblack/dsh-prompt-studio) — Edit user and built-in system-prompt sections with live preview.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -423,6 +423,15 @@
       }
     },
     {
+      "name": "dsh-balance-meter",
+      "url": "https://github.com/Ghost011118/dsh-balance-meter",
+      "category": "developer-tools",
+      "description": {
+        "en": "Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.",
+        "zh-CN": "在 DSH Web 输入框下方实时显示 DeepSeek 账户余额与本场会话花费，自动抓取官方价格并支持峰谷计价。"
+      }
+    },
+    {
       "name": "dsh-qq2006",
       "url": "https://github.com/LaplaceYoung/dsh-qq2006",
       "category": "ai-design-media",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -56,6 +56,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) — 在 DSH Web 中嵌入隔离网页预览，通过元素批注和可视化调整指导源码修改。
 
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — 在 DSH Web 输入框下方实时显示 DeepSeek 账户余额与本场会话花费，自动抓取官方价格并支持峰谷计价。
+
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 基于浏览器的 Plugin 管理控制台，并提供官方 DSH Plugin 开发引导。
 
 - [Prompt Studio](https://github.com/Moeblack/dsh-prompt-studio) — 编辑用户与内置系统提示词段落，支持实时预览。


### PR DESCRIPTION
Adds dsh-balance-meter to developer-tools in catalog/plugins.json plus the generated English and Simplified Chinese indexes.

dsh-balance-meter shows the live DeepSeek account balance and current session cost in the DSH Web composer dock, with auto-fetched official pricing (refreshed every 6h) and peak/off-peak hour support. Install via `dsh plugin --profile web add dsh-balance-meter` (npm: dsh-balance-meter@0.1.0).