### PR TITLE
Add deepseek-harness-acp

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi — the model decides when and what to compress.
 
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) — An ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while sharing DSH credentials and sessions.
+
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — A send_artifact tool that validates model-produced files and delivers structured descriptors through the standard dsh event stream for any client to render.
 
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) — Automatically detects and decodes Bash output encodings including UTF-16LE, UTF-8, and GBK for Windows and WSL.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -499,6 +499,15 @@
       }
     },
     {
+      "name": "deepseek-harness-acp",
+      "url": "https://github.com/openma-ai/deepseek-harness-acp",
+      "category": "developer-tools",
+      "description": {
+        "en": "An ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while sharing DSH credentials and sessions.",
+        "zh-CN": "ACP profile 插件与独立 server，把完整 DSH agent 接入 Zed 等 ACP 客户端，并共享 DSH 凭据与会话。"
+      }
+    },
+    {
       "name": "dsh-turn-index",
       "url": "https://github.com/Simon314620/dsh-turn-index",
       "category": "ui-user-experience",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -40,6 +40,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — 面向 DeepSeek Harness 的模型驱动上下文压缩（ACP），移植自 billion-context-pi——由模型决定何时压缩、压缩什么。
 
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) — ACP profile 插件与独立 server，把完整 DSH agent 接入 Zed 等 ACP 客户端，并共享 DSH 凭据与会话。
+
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — 提供 send_artifact 工具，校验模型产出的文件并通过 dsh 标准事件流交付结构化描述子，任何客户端都可按需呈现。
 
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — 在 DSH Web 输入框下方实时显示 DeepSeek 账户余额与本场会话花费，自动抓取官方价格并支持峰谷计价。


### PR DESCRIPTION
## What changed

Adds `openma-ai/deepseek-harness-acp` to the catalog source and regenerates both language versions.

## Why

The project is a DSH profile plugin and standalone ACP server that exposes the full harness to Zed and other ACP clients while sharing credentials and durable sessions.

## User impact

Readers can discover an editor integration that retains the host harness's tools, providers, permissions, and persistence.

## Checks

- `python3 scripts/generate_readmes.py`
- `python3 scripts/generate_readmes.py --check`
- `jq empty catalog/plugins.json`
- `git diff --check`
