### PR TITLE
Add dsh-mneme cross-session memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — Adds long-term cross-session memory with Git-branch awareness and background skill evolution.
 
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) — Adds cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror, autoDream background consolidation, 106 tests.
+
 - [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) — Brings the local OpenBiliClaw content-recommendation agent into DSH with a persistent UI and 22 agent-bridge tools.
 
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) — Provides full-text search across DSH, Codex, Claude Code, pi, and OpenCode sessions.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -445,6 +445,15 @@
       }
     },
     {
+      "name": "dsh-mneme",
+      "url": "https://github.com/modusensus/dsh-mneme",
+      "category": "data-research-knowledge",
+      "description": {
+        "en": "Cross-session memory with memory sovereignty: SQLite + human-editable Markdown mirror, autoDream background consolidation, 6 memory tools, 140 tests.",
+        "zh-CN": "把记忆主权还给人的跨会话记忆插件：SQLite + 可人工编辑的 Markdown 双写，autoDream 后台巩固（去重/合并/裁决），6 个记忆工具，140 个测试护航。"
+      }
+    },
+    {
       "name": "dsh-data-agent",
       "url": "https://github.com/dsh-external/dsh-data-agent",
       "category": "data-research-knowledge",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -136,6 +136,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — 提供带 Git 分支感知和后台技能进化能力的跨会话长期记忆。
 
+- [dsh-mneme](https://github.com/modusensus/dsh-mneme) — 把记忆主权还给人的跨会话记忆插件：SQLite + 可人工编辑的 Markdown 双写，autoDream 后台巩固（去重/合并/裁决），6 个记忆工具，140 个测试护航。
+
 - [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) — 将本地 OpenBiliClaw 内容推荐智能体接入 DSH，提供常驻界面和 22 个 Agent Bridge 工具。
 
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) — 支持跨 DSH、Codex、Claude Code、pi 与 OpenCode 会话的全文搜索。


### PR DESCRIPTION
Add [dsh-mneme](https://github.com/modusensus/dsh-mneme) — cross-session memory plugin for DeepSeek Harness: SQLite + human-editable Markdown mirror (memory sovereignty), autoDream background consolidation, 106 tests. MIT.