### PR TITLE
docs: add dsh-chat-import to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) — Lets DeepSeek Harness cite relevant conversation history from Codex and Claude Code.
 
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Imports chat histories from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, and opencode into resumable DSH sessions.
+
 - [dsh-data-agent](https://github.com/dsh-external/dsh-data-agent) — Helps agents connect to databases and write SQL for data tasks.
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — Adds long-term cross-session memory with Git-branch awareness and background skill evolution.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -436,6 +436,15 @@
       }
     },
     {
+      "name": "dsh-chat-import",
+      "url": "https://github.com/Nwflower/dsh-chat-import",
+      "category": "data-research-knowledge",
+      "description": {
+        "en": "Imports chat histories from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, and opencode into resumable DSH sessions.",
+        "zh-CN": "导入 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录，在 DSH 中重建为可继续（resume）的会话。"
+      }
+    },
+    {
       "name": "dsh-memory-evolve",
       "url": "https://github.com/dsh-external/dsh-memory-evolve",
       "category": "data-research-knowledge",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -136,6 +136,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) — 让 DeepSeek Harness 引用 Codex 与 Claude Code 中相关的历史对话。
 
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 导入 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 的聊天记录，在 DSH 中重建为可继续（resume）的会话。
+
 - [dsh-data-agent](https://github.com/dsh-external/dsh-data-agent) — 帮助智能体连接数据库并编写 SQL 以完成数据任务。
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — 提供带 Git 分支感知和后台技能进化能力的跨会话长期记忆。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

`dsh-chat-import` is a DSH Host plugin that imports external chat histories — from Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, and opencode — into DSH as fully resumable sessions, preserving the original conversation fidelity. It sits naturally in the **Data, research & knowledge** category alongside the other cross-tool conversation utilities (`cross-harness-cite`, `dsh-session-search`).

Changes in this PR:

- `README.md` — English entry in "Data, research & knowledge".
- `catalog/plugins.json` — bilingual (`en` / `zh-CN`) metadata for the entry.
- `docs/README.zh-CN.md` — regenerated Simplified Chinese mirror via `python scripts/generate_readmes.py`; `--check` passes.
