### PR TITLE
Add dsh-billing to the plugin catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.
 
+- [dsh-billing](https://github.com/TheTianzz/dsh-billing) — DeepSeek account balance and per-session cost as header pills, slash commands, and an agent tool, with configurable pricing and automatic 12-hour sync of the official price list.
+
 - [plugin-registry](https://github.com/vlln/plugin-registry) — A browser-based plugin management console with official guidance for creating DSH plugins.
 
 ### UI & user experience

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -472,6 +472,15 @@
       }
     },
     {
+      "name": "dsh-billing",
+      "url": "https://github.com/TheTianzz/dsh-billing",
+      "category": "developer-tools",
+      "description": {
+        "en": "DeepSeek account balance and per-session cost as header pills, slash commands, and an agent tool, with configurable pricing and automatic 12-hour sync of the official price list.",
+        "zh-CN": "以会话头部双胶囊、斜杠命令和智能体工具展示 DeepSeek 账户余额与本会话费用，单价可配置并每 12 小时自动同步官方价格。"
+      }
+    },
+    {
       "name": "dsh-qq2006",
       "url": "https://github.com/LaplaceYoung/dsh-qq2006",
       "category": "ui-user-experience",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -48,6 +48,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) — 自动识别并解码 UTF-16LE、UTF-8、GBK 等 Bash 输出编码，修复 Windows 与 WSL 下的乱码。
 
+- [dsh-billing](https://github.com/TheTianzz/dsh-billing) — 以会话头部双胶囊、斜杠命令和智能体工具展示 DeepSeek 账户余额与本会话费用，单价可配置并每 12 小时自动同步官方价格。
+
 - [dsh-custom-tool](https://github.com/FSMargoo/dsh-custom-tool) — 通过 Monaco 编辑器及模型驱动的生命周期创建和管理沙箱化 JavaScript 工具。
 
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — 将 Git 提交作者身份固定为当前环境身份，并优先使用已登录的 GitHub CLI 账号。


### PR DESCRIPTION
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/Alex-Yanggg/awesome-DSH-plugin/blob/main/CONTRIBUTING.md).
- [x] The plugin is a DeepSeek Harness plugin with a stable public URL: https://github.com/TheTianzz/dsh-billing (npm: `dsh-billing`).
- [x] English entry added to `README.md` (Developer tools, alphabetical).
- [x] Bilingual metadata added to `catalog/plugins.json`.
- [x] Generated and validated the zh-CN mirror (`scripts/generate_readmes.py --check` passes).

**About the plugin**: dsh-billing shows DeepSeek account balance and per-session API cost as conversation-header pills in the DSH Web UI, plus `/balance` and `/cost` slash commands and an agent-callable `deepseek_billing` tool. Prices are configurable and auto-synced from the official pricing page every 12 hours (peak/off-peak aware). Install: `dsh plugin --profile web add dsh-billing`.