### PR TITLE
docs: 登记 dsh-chat-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.
 
 - [plugin-registry](https://github.com/vlln/plugin-registry) — A browser-based plugin management console with official guidance for creating DSH plugins.
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.
 
 ### UI & user experience
 


### PR DESCRIPTION
## 插件信息

| 项 | 值 |
|---|---|
| 插件名 | dsh-chat-import |
| 仓库 | https://github.com/Nwflower/dsh-chat-import |
| 一句话说明 | 13 种编码 Agent 聊天记录全保真导入为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code |
| 版本 | 0.3.1（npm `dsh-chat-import`） |

## 自检清单

- [x] 仓库已打 `dsh-plugin` topic
- [x] npm 已发布（0.1.0–0.3.1），340 测试 + CI 全绿
- [x] 13 个 `import_*` 工具 + `scan_discover` / `export_claude` / `sync_to_claude` / `list_imported_sessions` / `retract_import` 实测通过

## 改动内容

在 `### Developer tools` 分类末尾（`plugin-registry` 之后）追加：

`- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.`