### PR TITLE
Add dsh-reverse-skill (85-skill reverse-engineering pack) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 > The catalog links to third-party projects. Review a plugin's source, permissions, and data-handling policy before installing it.
 
 ## Plugin catalog
+- [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 ### Developer tools
 


### PR DESCRIPTION
Adds [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — a DeepSeek Harness Cordis plugin bundling 85 SKILL.md reverse-engineering / authorized-pentest / security-research skills.

Installable via `dsh plugin add github:dhicoc/dsh-reverse-skill`.