### PR TITLE
docs: add toolclub/dsh-agent-team-gui v0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — A skill-driven workflow agent plugin for structured harness-loop engineering.
 
-- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
+- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — Persistent multi-model teams managed in the Web UI, with lead-Agent DAG planning, bounded role-scoped execution, optional review/repair, durable run history, and provider-reported Token usage.
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation that routes irreversible operations to human approval.
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — A skill-driven workflow agent plugin for structured harness-loop engineering.
 
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.
+
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation that routes irreversible operations to human approval.
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — A shared multi-agent task board backed by a Cordis service key.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — A skill-driven workflow agent plugin for structured harness-loop engineering.
 
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
+- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation that routes irreversible operations to human approval.
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — A skill-driven workflow agent plugin for structured harness-loop engineering.
 
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation that routes irreversible operations to human approval.
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -94,6 +94,15 @@
       }
     },
     {
+      "name": "dsh-agent-team-gui",
+      "url": "https://github.com/toolclub/agent_team_gui",
+      "category": "agent-automation",
+      "description": {
+        "en": "Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.",
+        "zh-CN": "可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。"
+      }
+    },
+    {
       "name": "dsh-custom-tool",
       "url": "https://github.com/FSMargoo/dsh-custom-tool",
       "category": "developer-tools",

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -95,7 +95,7 @@
     },
     {
       "name": "dsh-agent-team-gui",
-      "url": "https://github.com/toolclub/agent_team_gui",
+      "url": "https://github.com/toolclub/dsh-agent-team-gui",
       "category": "agent-automation",
       "description": {
         "en": "Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.",

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -98,8 +98,8 @@
       "url": "https://github.com/toolclub/agent_team_gui",
       "category": "agent-automation",
       "description": {
-        "en": "Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.",
-        "zh-CN": "可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。"
+        "en": "Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.",
+        "zh-CN": "全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。"
       }
     },
     {

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -98,8 +98,8 @@
       "url": "https://github.com/toolclub/dsh-agent-team-gui",
       "category": "agent-automation",
       "description": {
-        "en": "Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.",
-        "zh-CN": "全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。"
+        "en": "Persistent multi-model teams managed in the Web UI, with lead-Agent DAG planning, bounded role-scoped execution, optional review/repair, durable run history, and provider-reported Token usage.",
+        "zh-CN": "在 Web UI 中管理持久化多模型 Agent 小队，支持主 Agent 规划 DAG、有界的角色任务执行、可选审核与修复、持久运行历史以及 Provider 上报的 Token 用量。"
       }
     },
     {

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -144,7 +144,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 ### 智能体编排与自动化
 
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — 可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — DSH 风险门控自动审批：安全操作自动批准，风险操作转人工审批。
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -144,7 +144,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 ### 智能体编排与自动化
 
-- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
+- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — 在 Web UI 中管理持久化多模型 Agent 小队，支持主 Agent 规划 DAG、有界的角色任务执行、可选审核与修复、持久运行历史以及 Provider 上报的 Token 用量。
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — DSH 风险门控自动审批：安全操作自动批准，风险操作转人工审批。
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -144,6 +144,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 ### 智能体编排与自动化
 
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — 可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。
+
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — DSH 风险门控自动审批：安全操作自动批准，风险操作转人工审批。
 
 - [dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — 让智能体在会话中现场编写、热挂载并可逆卸载自己的 cordis 插件，新工具、提示词规则和事件钩子重启后自动恢复。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -144,7 +144,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 ### 智能体编排与自动化
 
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) — 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
+- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) — 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — DSH 风险门控自动审批：安全操作自动批准，风险操作转人工审批。
 


### PR DESCRIPTION
## Summary

Canonical repository: [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui)

Adds **dsh-agent-team-gui** under Agent orchestration & automation with matching bilingual catalog metadata and the generated Simplified Chinese page.

The entry now describes the released v0.5 product: persistent multi-model teams managed in the Web UI, lead-Agent bounded DAG planning, role-scoped execution, optional review/repair, durable run history, and provider-reported Token usage.

## Published v0.5 release

- Release: [v0.5.0](https://github.com/toolclub/dsh-agent-team-gui/releases/tag/v0.5.0)
- Release commit: [`6ce4453e087f15ae71e0b5b3ec4d61780c88938b`](https://github.com/toolclub/dsh-agent-team-gui/commit/6ce4453e087f15ae71e0b5b3ec4d61780c88938b)
- Install: `dsh plugin --profile web add -w github:toolclub/dsh-agent-team-gui#v0.5.0`
- Compiled tarball: [`dsh-agent-team-gui-0.5.0.tgz`](https://github.com/toolclub/dsh-agent-team-gui/releases/download/v0.5.0/dsh-agent-team-gui-0.5.0.tgz)
- Tarball SHA-256: `8b7bf724ea889e1ecc54cc30d1c5d3aca396dc1809b5be9b6628e29491f5d71d`

## v0.5 capabilities reflected in the entry

- persistent reusable teams with independent provider/model and tool policy per member;
- lead-Agent dynamic planning into a validated, bounded dependency graph;
- finite concurrency, retry/cancel, optional quality review and repair;
- durable restart-safe run history and project/conversation/one-shot modes;
- provider-reported input/cache/output Token usage without invented pricing;
- Web UI management, Run Center, Insights, EN/ZH locale, keyboard and narrow-screen support.

## Plugin submission checklist

- [x] Installable DeepSeek Harness plugin with `dsh.bundle` and `dsh.client` manifests.
- [x] Canonical public repository URL.
- [x] Concise English and Simplified Chinese descriptions.
- [x] Existing agent-automation category.
- [x] `python3 scripts/generate_readmes.py --check` passes.
- [x] Maintainer edits enabled.

## Validation

Catalog contribution:

- `python3 scripts/generate_readmes.py`
- `python3 scripts/generate_readmes.py --check`
- `git diff --check`

Published plugin release:

- Node 22.19 and Node 24 quality matrices;
- 117 Host tests and 62 rendered Client tests;
- fresh DSH `0.1.0-rc.6` Web install and restart;
- exact release tarball audit/install and Playwright browser journey;
- Axe serious/critical, keyboard, light/dark, and 390 px layout gates.
