### PR TITLE
Add dsh-mcp-lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — Pins Git commit authorship to the active environment identity, prioritizing the signed-in GitHub CLI account.
 
+- [dsh-mcp-lens](https://github.com/labmimors/dsh-mcp-lens) — A progressive-disclosure MCP gateway for DeepSeek Harness that exposes two model-facing tools, retrieves ranked remote schemas on demand, and calls an explicit server/tool pair.
+
 - [dsh-open-in-vscode](https://github.com/FSMargoo/dsh-open-in-vscode) — Open DeepSeek Harness workspace directories in VS Code from the web interface.
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -157,6 +157,17 @@
       }
     },
     {
+      "name": "dsh-mcp-lens",
+      "url": "https://github.com/labmimors/dsh-mcp-lens",
+      "category": "developer-tools",
+      "description": {
+        "en": "A progressive-disclosure MCP gateway for DeepSeek Harness that exposes two model-facing tools, retrieves ranked remote schemas on demand, and calls an explicit server/tool pair.",
+        "zh-CN": "面向 DeepSeek Harness 的渐进式披露 MCP 网关：仅暴露两个面向模型的工具，按需检索排序后的远程 Schema，并调用明确的 server/tool 组合。"
+      },
+      "status": "active",
+      "source": "community"
+    },
+    {
       "name": "dsh-browser-panel",
       "url": "https://github.com/dsh-external/dsh-browser-panel",
       "category": "ui-user-experience",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -64,6 +64,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 一个将令牌同步到 gh CLI 配置的可视化 GitHub 设备码登录工具。
 
+- [dsh-mcp-lens](https://github.com/labmimors/dsh-mcp-lens) — 面向 DeepSeek Harness 的渐进式披露 MCP 网关：仅暴露两个面向模型的工具，按需检索排序后的远程 Schema，并调用明确的 server/tool 组合。
+
 - [dsh-open-in-vscode](https://github.com/FSMargoo/dsh-open-in-vscode) — 可从 DeepSeek Harness Web 界面直接在 VS Code 中打开工作区目录。
 
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) — DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。


### PR DESCRIPTION
## What changed

- add `dsh-mcp-lens` to the English Developer tools catalog;
- add matching English and Simplified Chinese catalog metadata; and
- regenerate the Simplified Chinese index.

## Why

`dsh-mcp-lens` is a public DeepSeek Harness plugin maintained by @labmimors, the submitter of this entry. The description is limited to its documented interface and routing behavior.

## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category: `developer-tools`.
- [x] I ran `python3 scripts/generate_readmes.py --check` successfully.

## Validation

- `python3 scripts/generate_readmes.py`
- `python3 scripts/generate_readmes.py --check`
- `git diff --check`

## Notes

This is a maintainer submission from `labmimors`. No new category is required.