### PR TITLE
Add dsh-MusicPlayer to UI & user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — A plugin manager and GitHub dsh-plugin marketplace for the DSH Web UI.
 - [dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) — A DSH Web GUI theme studio with presets, custom palettes, and instant theme switching.
 
+- [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) — A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.
+
 ### Agent orchestration & automation
 
 - [dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — Lets the agent write, hot-mount, and reversibly remove its own cordis plugins mid-session, growing new tools, prompt rules, and event hooks that persist across restarts.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,12 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "dsh-MusicPlayer",
+      "url": "https://github.com/xiekai886/dsh-MusicPlayer",
+      "category": "ui-user-experience",
+      "description": {"en": "A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.", "zh-CN": "可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。"}
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -108,6 +108,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-minigames](https://github.com/lhh010/dsh-minigames) — 为 DSH Web UI 添加可扩展的 18 款离线小游戏面板，适合等待智能体工作时休息。
 
+- [dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) — 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
+
 - [dsh-navbar](https://github.com/vlln/dsh-navbar) — 添加右侧对话节点导航条，可快速跳转到各个用户消息节点。
 
 - [dsh-paste-input](https://github.com/lhh010/dsh-paste-input) — 增强文件输入，支持粘贴、拖拽和选择文件；发送时自动将文件复制到会话工作区。


### PR DESCRIPTION
Add [dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) under **UI & user experience** (ui-user-experience) in Alex-Yanggg/awesome-DSH-plugin.

**dsh-MusicPlayer** is a floating music player plugin for DeepSeek Harness Web: collapsible/expandable draggable frosted-glass card, NetEase Cloud Music playlist import (link/ID) and song/artist search with one-click add, multi-layer audio source resolution (Meting → outer/url), and an agent-facing music tool — chat and listen at the same time.

Per CONTRIBUTING.md:
- [x] English entry added to README.md (hand-maintained)
- [x] Bilingual metadata added to catalog/plugins.json (en + zh-CN, category ui-user-experience)
- [x] Simplified Chinese mirror generated: python scripts/generate_readmes.py
- [x] Validated: python scripts/generate_readmes.py --check passes
- [x] Plugin declares dsh.bundle manifest, real working code, dsh-plugin topic added