### PR TITLE
Add mirage-dsh to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — An in-app DSH Web UI plugin store with browsing, search, installation, compatibility badges, and an installed list.
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — Advanced form- and file-level settings management with a plugin settings registration SDK.
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) — An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.
+- [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) — Replaces the DSH filesystem and bash providers with a mirage virtual workspace, so file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk.
 
 ### UI & user experience
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,12 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "mirage-dsh",
+      "url": "https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh",
+      "category": "developer-tools",
+      "description": {"en": "Replaces the DSH filesystem and bash providers with a mirage virtual workspace, so file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk.", "zh-CN": "把 DSH 的文件系统与 bash 提供者换成 mirage 虚拟工作区，文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘。"}
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -76,6 +76,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。
 
+- [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) — 把 DSH 的文件系统与 bash 提供者换成 mirage 虚拟工作区，文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘。
+
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店，支持浏览、搜索、安装、兼容徽章和已装列表。
 
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 基于浏览器的 Plugin 管理控制台，并提供官方 DSH Plugin 开发引导。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

`mirage-dsh` is a DSH bundle that provides `ctx.fs` and `ctx.shell` from a mirage virtual workspace, so the agent's file tools and shell commands act on mounted resources rather than the host disk. Mounts carry per-mount read/write/exec modes, and commands can be routed to different sandboxes (monty, pyodide and quickjs in process; docker, e2b and daytona remote).

- npm: [`@struktoai/mirage-dsh`](https://www.npmjs.com/package/@struktoai/mirage-dsh) (ships `dsh.bundle.patch` + `cordis.patch.yml`)
- Install: `dsh plugin --profile web add @struktoai/mirage-dsh`
- License: Apache-2.0. I maintain the project.

Category: **Developer tools**, next to the other runtime and tooling plugins. The URL points at the plugin package inside the monorepo, following the same convention as the existing `create-dsh-plugin` and `plugin-manager` entries.
