### PR TITLE
Add dsh-engramory to Data, research & knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-artifact-library](https://github.com/wyq183/dsh-artifact-library) — Local-first artifact & reference library: auto-collects AI outputs, AI-organizes them with summaries and tags, full-text search across sessions, and per-project overview.
 
+- [dsh-engramory](https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh) — File-based curated memory: a line/byte-capped MEMORY.md index plus one markdown file per fact under git, with the cap enforced by ctx.tools.guard() and the same store also read by Claude Code, Codex, Kiro, and OpenClaw.
+
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — Adds long-term cross-session memory with Git-branch awareness and background skill evolution.
 
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) — Cross-session memory for DeepSeek Harness: SQLite + human-editable Markdown mirror, autoDream consolidation, six memory tools, and fully-offline semantic search (local embedding / rerank / clustering), 198 tests.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-artifact-library](https://github.com/wyq183/dsh-artifact-library) — Local-first artifact & reference library: auto-collects AI outputs, AI-organizes them with summaries and tags, full-text search across sessions, and per-project overview.
 
-- [dsh-engramory](https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh) — File-based curated memory: a line/byte-capped MEMORY.md index plus one markdown file per fact under git, with the cap enforced by ctx.tools.guard() and the same store also read by Claude Code, Codex, Kiro, and OpenClaw.
+- [dsh-engramory](https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh/plugin) — File-based curated memory as an installable plugin (npm: dsh-engramory): a line/byte-capped MEMORY.md index plus one markdown file per fact under git, with the cap enforced by ctx.tools.guard() and the same store also read by Claude Code, Codex, Kiro, and OpenClaw.
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — Adds long-term cross-session memory with Git-branch awareness and background skill evolution.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -618,6 +618,15 @@
       }
     },
     {
+      "name": "dsh-engramory",
+      "url": "https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh",
+      "category": "data-research-knowledge",
+      "description": {
+        "en": "File-based curated memory: a line/byte-capped MEMORY.md index plus one markdown file per fact under git, with the cap enforced by ctx.tools.guard() and the same store also read by Claude Code, Codex, Kiro, and OpenClaw.",
+        "zh-CN": "基于文件的策展式记忆：带行数/字节上限的 MEMORY.md 索引加每条事实一个 markdown 文件并由 git 版本化，上限由 ctx.tools.guard() 强制执行，同一份记忆库也被 Claude Code、Codex、Kiro 与 OpenClaw 读取。"
+      }
+    },
+    {
       "name": "dsh-spend",
       "url": "https://github.com/nonewind/dsh-spend",
       "category": "developer-tools",

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -619,11 +619,11 @@
     },
     {
       "name": "dsh-engramory",
-      "url": "https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh",
+      "url": "https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh/plugin",
       "category": "data-research-knowledge",
       "description": {
-        "en": "File-based curated memory: a line/byte-capped MEMORY.md index plus one markdown file per fact under git, with the cap enforced by ctx.tools.guard() and the same store also read by Claude Code, Codex, Kiro, and OpenClaw.",
-        "zh-CN": "基于文件的策展式记忆：带行数/字节上限的 MEMORY.md 索引加每条事实一个 markdown 文件并由 git 版本化，上限由 ctx.tools.guard() 强制执行，同一份记忆库也被 Claude Code、Codex、Kiro 与 OpenClaw 读取。"
+        "en": "File-based curated memory as an installable plugin (npm: dsh-engramory): a line/byte-capped MEMORY.md index plus one markdown file per fact under git, with the cap enforced by ctx.tools.guard() and the same store also read by Claude Code, Codex, Kiro, and OpenClaw.",
+        "zh-CN": "基于文件的策展式记忆，可安装插件（npm: dsh-engramory）：带行数/字节上限的 MEMORY.md 索引加每条事实一个 markdown 文件并由 git 版本化，上限由 ctx.tools.guard() 强制执行，同一份记忆库也被 Claude Code、Codex、Kiro 与 OpenClaw 读取。"
       }
     },
     {

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -186,6 +186,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-data-agent](https://github.com/dsh-external/dsh-data-agent) — 帮助智能体连接数据库并编写 SQL 以完成数据任务。
 
+- [dsh-engramory](https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh) — 基于文件的策展式记忆：带行数/字节上限的 MEMORY.md 索引加每条事实一个 markdown 文件并由 git 版本化，上限由 ctx.tools.guard() 强制执行，同一份记忆库也被 Claude Code、Codex、Kiro 与 OpenClaw 读取。
+
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — 提供带 Git 分支感知和后台技能进化能力的跨会话长期记忆。
 
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) — 面向 DeepSeek Harness 的跨会话记忆插件：SQLite + 可人工编辑的 Markdown 双写，autoDream 后台巩固，6 个记忆工具，完全离线语义检索（本地向量 / 精排 / 聚类），198 个测试。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

Adds **dsh-engramory** under *Data, research & knowledge*: `catalog/plugins.json` for the bilingual metadata, the hand-maintained English entry in `README.md`, and `docs/README.zh-CN.md` regenerated by the script (`--check` reports "Catalog is valid and generated pages are current").

**What it does.** File-based curated memory — a line/byte-capped `MEMORY.md` index plus one markdown file per fact, versioned with git and readable without any tool. The plugin enforces that cap through `ctx.tools.guard()`, so an oversized index write is refused rather than discouraged, and registers the protocol as a runtime skill through `ctx.skills.register()`. The same store is also read by Claude Code, Codex, Kiro, and OpenClaw.

**On the URL.** It points at [`adapters/dsh/`](https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh) rather than the repository root: the root is the host-agnostic memory protocol, while that subdirectory is the DeepSeek Harness adapter and its README. The plugin package itself is [`adapters/dsh/plugin/`](https://github.com/tinqiao-oss/engramory/tree/master/adapters/dsh/plugin), published to npm as [`dsh-engramory`](https://www.npmjs.com/package/dsh-engramory) with a `dsh.bundle` manifest. Happy to switch the link to the repository root if you prefer consistency with other entries.

**Installation caveat, stated up front.** The wiring was dogfooded end to end against a live `deepseek-v4-flash` session. However, installing *any* third-party plugin into a profile currently fails upstream on dsh 0.1.0-rc.6: `dsh plugin` shells out to a `pnpm` it does not bundle, and a direct `pnpm add` then fails with `ERR_PNPM_FETCH_404` for `@deepseek-ai/dsh-type-meta`, which the published tree depends on but the registry does not carry. This is preview packaging upstream, not specific to this plugin — but if the catalog only lists plugins that install cleanly today, please hold this PR until that clears.
