### PR TITLE
Add dsh-passwords to Cloud, DevOps & observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) — Operations toolkit with A/B snapshot upgrades, automatic recovery, rollback, and a diagnostic self-healing command.
 
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — Login gateway (password door) for the DSH web UI with first-run setup, multi-user accounts, rate limiting, audit log, and automatic HTTPS.
+
 ### AI, design & media
 
 - [DSH OpenPencil](https://github.com/ZSeven-W/dsh-openpencil) — Connects DeepSeek Harness to OpenPencil so agents can create, edit, preview, and validate interactive, multi-page design canvases.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,12 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "dsh-passwords",
+      "url": "https://github.com/slywalker2006/dsh-passwords",
+      "category": "cloud-devops-observability",
+      "description": {"en": "Login gateway (password door) for the DSH web UI with first-run setup, multi-user accounts, rate limiting, audit log, and automatic HTTPS.", "zh-CN": "DSH 网页界面的登录网关（密码门）：首次配置、多用户账号、防爆破锁定、审计日志与自动 HTTPS。"}
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -202,6 +202,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) — 运维工具箱，提供 A/B 快照升级、自动恢复、回滚和诊断式自愈命令。
 
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) — DSH 网页界面的登录网关（密码门）：首次配置、多用户账号、防爆破锁定、审计日志与自动 HTTPS。
+
 ### AI、设计与媒体
 
 - [DSH OpenPencil](https://github.com/ZSeven-W/dsh-openpencil) — 连接 DeepSeek Harness 与 OpenPencil，让智能体创建、编辑、预览和验证可交互的多页面设计画布。


### PR DESCRIPTION
Add [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) to **Cloud, DevOps & observability**.

dsh-passwords is a login gateway (password door) for the DSH web UI: first-run setup, multi-user accounts, rate limiting, audit log, and automatic HTTPS (Let's Encrypt).

Changes:
- `README.md` — English entry in the Cloud, DevOps & observability section
- `catalog/plugins.json` — bilingual metadata (`cloud-devops-observability`)
- `docs/README.zh-CN.md` — regenerated via `python scripts/generate_readmes.py` (catalog validates clean)

- License: BSD-3-Clause
- Has the `dsh-plugin` topic

Closes #50
