### PR TITLE
Add dsh-tokenscope usage dashboard to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-billing](https://github.com/TheTianzz/dsh-billing) — DeepSeek account balance and per-session cost as header pills, slash commands, and an agent tool, with configurable pricing and automatic 12-hour sync of the official price list.
 
-- [dsh-tokenscope](https://github.com/HduSy/dsh-tokenscope) — Per-day token usage and estimated cost dashboard for the DSH settings panel, with per-model breakdown, cache-hit ratio, and a yearly activity heatmap.
+- [dsh-tokenscope](https://github.com/HduSy/dsh-tokenscope) — Per-day, per-week, and per-month token usage and estimated cost dashboard for the DSH settings panel, with per-model breakdown, cache-hit ratio, and a yearly activity heatmap.
 
 - [plugin-registry](https://github.com/vlln/plugin-registry) — A browser-based plugin management console with official guidance for creating DSH plugins.
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-billing](https://github.com/TheTianzz/dsh-billing) — DeepSeek account balance and per-session cost as header pills, slash commands, and an agent tool, with configurable pricing and automatic 12-hour sync of the official price list.
 
+- [dsh-tokenscope](https://github.com/HduSy/dsh-tokenscope) — Per-day token usage and estimated cost dashboard for the DSH settings panel, with per-model breakdown, cache-hit ratio, and a yearly activity heatmap.
+
 - [plugin-registry](https://github.com/vlln/plugin-registry) — A browser-based plugin management console with official guidance for creating DSH plugins.
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — Import full-fidelity conversation histories from 13 coding agents (Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode / ZCode / Grok Build / OpenClaw / Pi / Hermes / Kimi) as resumable DeepSeek Harness sessions, with reverse export/sync back to Claude Code.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,12 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "dsh-tokenscope",
+      "url": "https://github.com/HduSy/dsh-tokenscope",
+      "category": "developer-tools",
+      "description": {"en": "Per-day token usage and estimated cost dashboard for the DSH settings panel, with per-model breakdown, cache-hit ratio, and a yearly activity heatmap.", "zh-CN": "DSH 设置面板的按日 Token 用量与估算花费看板，含按模型分布、缓存命中占比与全年活跃热力图。"}
     }
   ]
 }

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -777,7 +777,7 @@
       "name": "dsh-tokenscope",
       "url": "https://github.com/HduSy/dsh-tokenscope",
       "category": "developer-tools",
-      "description": {"en": "Per-day token usage and estimated cost dashboard for the DSH settings panel, with per-model breakdown, cache-hit ratio, and a yearly activity heatmap.", "zh-CN": "DSH 设置面板的按日 Token 用量与估算花费看板，含按模型分布、缓存命中占比与全年活跃热力图。"}
+      "description": {"en": "Per-day, per-week, and per-month token usage and estimated cost dashboard for the DSH settings panel, with per-model breakdown, cache-hit ratio, and a yearly activity heatmap.", "zh-CN": "DSH 设置面板的按日、周、月 Token 用量与估算花费看板，含按模型分布、缓存命中占比与全年活跃热力图。"}
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -76,7 +76,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。
 
-- [dsh-tokenscope](https://github.com/HduSy/dsh-tokenscope) — DSH 设置面板的按日 Token 用量与估算花费看板，含按模型分布、缓存命中占比与全年活跃热力图。
+- [dsh-tokenscope](https://github.com/HduSy/dsh-tokenscope) — DSH 设置面板的按日、周、月 Token 用量与估算花费看板，含按模型分布、缓存命中占比与全年活跃热力图。
 
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店，支持浏览、搜索、安装、兼容徽章和已装列表。
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -76,6 +76,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。
 
+- [dsh-tokenscope](https://github.com/HduSy/dsh-tokenscope) — DSH 设置面板的按日 Token 用量与估算花费看板，含按模型分布、缓存命中占比与全年活跃热力图。
+
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店，支持浏览、搜索、安装、兼容徽章和已装列表。
 
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 基于浏览器的 Plugin 管理控制台，并提供官方 DSH Plugin 开发引导。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

- **Category**: `developer-tools`, alongside the other token/spend dashboards (`dsh-spend`, `dsh-billing`, `dsh-opencodego-usage`).
- **What it does**: aggregates the `session/event` usage stream on the host side and renders a token / estimated-cost dashboard in the DSH settings panel across **today / this week / this month** — per-model breakdown, cache-hit ratio, tool-call ranking, and a yearly activity heatmap (TokenScope-style).
- **Bilingual metadata** added to `catalog/plugins.json`; the Simplified Chinese mirror was regenerated with `python scripts/generate_readmes.py` and verified with `--check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
