### PR TITLE
Add `dsh-context` to UI & user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-ui-progress](https://github.com/lhh010/dsh-ui-progress) — Shows persistent conversation progress, live token generation speed, interruption state, and todo reminders in the Web UI.
 
+- [dsh-context](https://github.com/bowenliang123/dsh-context) — Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.
+
 - [dsh-ui-whale](https://github.com/lhh010/dsh-ui-whale) — A hand-drawn pixel whale companion for the DSH Web UI that reacts to agent activity.
 
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) — Embeds isolated web page previews in DSH Web for element annotations and visual adjustments that guide source edits.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -310,6 +310,15 @@
       }
     },
     {
+      "name": "dsh-context",
+      "url": "https://github.com/bowenliang123/dsh-context",
+      "category": "ui-user-experience",
+      "description": {
+        "en": "Context insight panel: see what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.",
+        "zh-CN": "上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。"
+      }
+    },
+    {
       "name": "dsh-input-history",
       "url": "https://github.com/lhh010/dsh-input-history",
       "category": "ui-user-experience",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -94,6 +94,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-cc-tui](https://github.com/ccch1mneyyy/dsh-cc-tui) — Claude Code 风格的全屏终端界面，提供流式思考展示、回滚控制及上下文/TPS 指示器。
 
+- [dsh-context](https://github.com/bowenliang123/dsh-context) — 上下文洞察面板：一眼看清模型上下文窗口的组成与变化——构成对照窗口大小、按请求历史趋势、压缩/注入事件、消息级 token 统计。
+
 - [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) — 在 DSH Web 页面右下角悬浮卡片展示 DeepSeek API 剩余额度，支持自动刷新与手动刷新。
 
 - [dsh-desktop](https://github.com/howlma/dsh-desktop) — Windows 桌面客户端：打开即拉起或复用 Harness 网关，窗口内嵌官方 Web 界面；托盘常驻，可选开机自启。


### PR DESCRIPTION
Adds [dsh-context](https://github.com/bowenliang123/dsh-context) under **UI & user experience**.

**Context insight panel** for DeepSeek Harness: adds a Context tab beside Chat/Trajectory to understand what the model's context window is made of and how it evolves — composition vs. window size, per-request history, compression/injection events, and per-message token stats.

Install:

```sh
dsh plugin --profile web add dsh-context
```

- Ships a dsh.bundle manifest (installable via `dsh plugin add`) + dsh.client manifest for the web UI half
- Bilingual EN/zh-CN metadata added to `catalog/plugins.json`, Simplified Chinese mirror regenerated
- `dsh-plugin` topic set; Apache-2.0 licensed
