### PR TITLE
Add cleverer-dsh: execution-discipline plugin suite for DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — A shared multi-agent task board backed by a Cordis service key.
 
+- [cleverer-dsh](https://github.com/Classicoke/cleverer-dsh) — An execution-discipline plugin suite for DeepSeek Harness: intercepts repeated failures, forces reflection, enforces todo discipline, dedups memory, and evolves its own skills.
+
 ### Productivity & collaboration
 
 - [deepseek-manners](https://github.com/Moeblack/deepseek-manners) — Appends a thank-you line to every assistant reply.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,12 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "cleverer-dsh",
+      "url": "https://github.com/Classicoke/cleverer-dsh",
+      "category": "agent-automation",
+      "description": {"en": "An execution-discipline plugin suite for DeepSeek Harness: intercepts repeated failures, forces reflection, enforces todo discipline, dedups memory, and evolves its own skills.", "zh-CN": "DeepSeek Harness 执行纪律插件套件：拦截重复失败、强制反思、强制任务规划纪律、记忆去重与技能自进化。"}
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -144,6 +144,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 ### 智能体编排与自动化
 
+- [cleverer-dsh](https://github.com/Classicoke/cleverer-dsh) — DeepSeek Harness 执行纪律插件套件：拦截重复失败、强制反思、强制任务规划纪律、记忆去重与技能自进化。
+
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — DSH 风险门控自动审批：安全操作自动批准，风险操作转人工审批。
 
 - [dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — 让智能体在会话中现场编写、热挂载并可逆卸载自己的 cordis 插件，新工具、提示词规则和事件钩子重启后自动恢复。


### PR DESCRIPTION
"## Plugin submission checklist\n\n- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.\n- [x] I used the canonical public project URL.\n- [x] I added concise English and Simplified Chinese descriptions.\n- [x] I chose an existing category (Agent orchestration & automation).\n- [x] I ran `python scripts/generate_readmes.py --check` successfully.\n\n## Notes\n\n[cleverer-dsh](https://github.com/Classicoke/cleverer-dsh) is an execution-discipline plugin suite for DeepSeek Harness — failure interception (denies identical retries), forced reflection, todo discipline, cross-session memory dedup, and self-evolving skills. 12 plugins + 6 skills, zero dependencies, never touches DSH source. It declares a `dsh.bundle` manifest, so it installs with a single `dsh plugin add github:Classicoke/cleverer-dsh` (no build step, no allowBuilds prompt). 478 unit tests; measured 49% faster / 44% fewer tokens on one real task vs bare DSH (small sample)."