### PR TITLE
docs: add DSH Plugins bilingual directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — A visual GitHub device-flow login tool that syncs its token into gh CLI config.
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — A living DeepSeek Harness plugin directory with a compatibility CI, searchable catalog, and in-app plugin store.
+- [DSH Plugins](https://dsh-plugin.top/) — A bilingual, star-ranked directory of 600+ DeepSeek Harness plugins with curated project summaries, install commands, localized detail pages, and an incremental GitHub star-growth view.
 - [create-dsh-plugin](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin) — A DSH plugin scaffolder with templates and a built-in smoke test.
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — An in-app DSH Web UI plugin store with browsing, search, installation, compatibility badges, and an installed list.
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — Advanced form- and file-level settings management with a plugin settings registration SDK.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -708,6 +708,15 @@
       "description": {"en": "A living DeepSeek Harness plugin directory with compatibility CI, a searchable catalog, and an in-app plugin store.", "zh-CN": "DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。"}
     },
     {
+      "name": "DSH Plugins",
+      "url": "https://dsh-plugin.top/",
+      "category": "developer-tools",
+      "description": {
+        "en": "A bilingual, star-ranked directory of 600+ DeepSeek Harness plugins with curated project summaries, install commands, localized detail pages, and an incremental GitHub star-growth view.",
+        "zh-CN": "收录 600 多个 DeepSeek Harness 插件的双语目录，提供按星标排序、人工整理的项目简介、安装命令、本地化详情页和增量涨星榜。"
+      }
+    },
+    {
       "name": "create-dsh-plugin",
       "url": "https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin",
       "category": "developer-tools",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -48,6 +48,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 一个为逆向工程和经授权安全研究路由 85 项技能包的 DeepSeek Harness Cordis 插件。
 
+- [DSH Plugins](https://dsh-plugin.top/) — 收录 600 多个 DeepSeek Harness 插件的双语目录，提供按星标排序、人工整理的项目简介、安装命令、本地化详情页和增量涨星榜。
+
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — 提供 send_artifact 工具，校验模型产出的文件并通过 dsh 标准事件流交付结构化描述子，任何客户端都可按需呈现。
 
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — 在 DSH Web 输入框下方实时显示 DeepSeek 账户余额与本场会话花费，自动抓取官方价格并支持峰谷计价。


### PR DESCRIPTION
## What changed

- Add DSH Plugins to the Developer tools catalog.
- Add matching English and Simplified Chinese metadata.
- Regenerate the Simplified Chinese README from the shared catalog.

## Why

DSH Plugins is an independent bilingual directory for 600+ DeepSeek Harness repositories. It complements the catalog with GitHub-star sorting, concise project summaries, install commands, localized detail pages, and an incremental star-growth view.

## User impact

Readers get another maintained discovery surface for browsing the DSH ecosystem in English or Chinese while retaining direct links to each original GitHub repository.

## Validation

- `python scripts/generate_readmes.py`
- `python scripts/generate_readmes.py --check`
- `git diff --check`
