### PR TITLE
docs: refresh TMCRA for unified 1.0.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) — Cross-session memory for DeepSeek Harness: SQLite + human-editable Markdown mirror, autoDream consolidation, six memory tools, and fully-offline semantic search (local embedding / rerank / clustering), 198 tests.
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon-powered local memory system with three-tier storage (runtime hot memory, project Documents, and long-term Memory Spaces), supervised writeback, retrieval tools, and a Web UI.
 
+- [TMCRA-Agent-Memory](https://github.com/reshuibuduo/TMCRA-Agent-Memory) — Owner-local graph memory for DSH and Codex that recalls owner-global and project evidence before each turn, stores USER and ASSISTANT records separately, and exposes a provenance-aware visual atlas and cited knowledge pages. (beta)
+
 - [dsh-openbiliclaw](https://github.com/whiteguo233/dsh-openbiliclaw) — Brings the local OpenBiliClaw content-recommendation agent into DSH with a persistent UI and 22 agent-bridge tools.
 
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) — Provides full-text search across DSH, Codex, Claude Code, pi, and OpenCode sessions.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,17 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "TMCRA-Agent-Memory",
+      "url": "https://github.com/reshuibuduo/TMCRA-Agent-Memory",
+      "category": "data-research-knowledge",
+      "description": {
+        "en": "Owner-local graph memory for DSH and Codex that recalls owner-global and project evidence before each turn, stores USER and ASSISTANT records separately, and exposes a provenance-aware visual atlas and cited knowledge pages.",
+        "zh-CN": "面向 DSH 与 Codex 的本机图记忆：每轮前召回用户全局与项目证据，分别保存 USER 与 ASSISTANT 记录，并提供保留来源信息的可视化图谱和带证据引用的知识页。"
+      },
+      "status": "beta",
+      "source": "community"
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -196,6 +196,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) — 支持跨 DSH、Codex、Claude Code、pi 与 OpenCode 会话的全文搜索。
 
+- [TMCRA-Agent-Memory](https://github.com/reshuibuduo/TMCRA-Agent-Memory) — 面向 DSH 与 Codex 的本机图记忆：每轮前召回用户全局与项目证据，分别保存 USER 与 ASSISTANT 记录，并提供保留来源信息的可视化图谱和带证据引用的知识页。 (beta)
+
 ### 云、DevOps 与可观测性
 
 - [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) — DeepSeek Harness 会话与当日 API 费用、预算与官方余额统计插件：历史看板、峰谷计价与官方价格一键同步。


### PR DESCRIPTION
## Plugin submission checklist

- [x] Maintained DeepSeek Harness lifecycle plugin, public Apache-2.0 source.
- [x] Canonical repository and existing category/beta status retained.
- [x] English catalog and generated Simplified Chinese entry updated together.
- [x] `python scripts/generate_readmes.py --check` passes.

Refresh the existing TMCRA entry for the published unified 1.0.0-rc.1 candidate.

Release: https://github.com/reshuibuduo/tmcra-plugin-deepseek-harness/releases/tag/v1.0.0-rc.1
Tarball: https://github.com/reshuibuduo/tmcra-plugin-deepseek-harness/releases/download/v1.0.0-rc.1/dsh-tmcra-memory-1.0.0-rc.1.tgz

Adds a visual memory workspace, local Writer/organizer configuration, knowledge/graph inspection, chat-confirmed corrections, session modes, and account-free Windows x64 one-click local-installation preview. User confirms the installation in the workbench; initial downloads require internet. Local memory then requires no TMCRA account/server. Full model acceptance is partial (complex CPU compilation timed out; organizer/restart/higher-tier hardware remain pending).

Typecheck, 20 unit tests, provider contracts, real DSH 0.1.1-rc.2 package/profile/Web boot, and account-free setup tests pass. Published artifact and checksum are present; no npm publication is claimed.