### PR TITLE
Add dsh-bell-notify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) — Exports append-only session logs as Markdown or HTML.
 - [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) — A Feishu meeting reminder panel with today/tomorrow views and flashing alarms.
 - [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) — A multi-platform IM gateway for Feishu, WeCom, and Telegram with per-chat agent sessions.
+- [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) — Plays a distinct chime per lifecycle event (startup, tool call, command, approval wait, turn complete, idle), synthesized live with Web Audio — zero audio files — plus a breathing status dot showing agent state.
 
 ### Data, research & knowledge
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -762,6 +762,12 @@
       "description": {"en": "Multi-platform IM gateway for DeepSeek Harness with Feishu, WeCom, and Telegram integrations and per-chat agent sessions.", "zh-CN": "DeepSeek Harness 多平台 IM 网关，集成飞书、企业微信和 Telegram，并提供每聊天独立智能体会话。"}
     },
     {
+      "name": "dsh-bell-notify",
+      "url": "https://github.com/Laplace-bit/dsh-bell-notify",
+      "category": "productivity-collaboration",
+      "description": {"en": "Plays a distinct chime per lifecycle event (startup, tool call, command, approval wait, turn complete, idle), synthesized live with Web Audio (zero audio files), plus a breathing status dot showing agent state.", "zh-CN": "为每个生命周期环节（启动、工具调用、命令、等待审批、回合完成、空闲）播放专属提示音，Web Audio 实时合成（零音频文件），外加一个显示工作状态的呼吸状态点。"}
+    },
+    {
       "name": "dsh-theme-plugin",
       "url": "https://github.com/BeiZi6/dsh-theme-plugin",
       "category": "ui-user-experience",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -162,6 +162,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [deepseek-manners](https://github.com/Moeblack/deepseek-manners) — 给每次助手回复追加一句感谢语。
 
+- [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) — 为每个生命周期环节（启动、工具调用、命令、等待审批、回合完成、空闲）播放专属提示音，Web Audio 实时合成（零音频文件），外加一个显示工作状态的呼吸状态点。
+
 - [dsh-companion](https://github.com/william-jin-cmu/dsh-companion) — Cetus macOS 桌面智能体的 DeepSeek Harness 发行版：常驻桌面聊天伙伴，支持全局快捷键、屏幕上下文、定时任务和文件递送。
 
 - [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) — DeepSeek Harness 多平台 IM 网关，集成飞书、企业微信和 Telegram，并提供每聊天独立智能体会话。


### PR DESCRIPTION
## Summary

Add [dsh-bell-notify](https://github.com/Laplace-bit/dsh-bell-notify) to the **Productivity & collaboration** category:

- `README.md` — English entry added (hand-maintained catalog)
- `catalog/plugins.json` — bilingual `en` / `zh-CN` metadata added
- `docs/README.zh-CN.md` — regenerated via `scripts/generate_readmes.py`

`dsh-bell-notify` plays a distinct chime per lifecycle event (startup, tool call, command, approval wait, turn complete, idle), synthesized live with Web Audio — zero audio files — plus a breathing status dot showing what the agent is doing. Each sound can be previewed, replaced with your own audio file, and reset from a settings panel; custom sounds persist locally.

## Verification

- `python scripts/generate_readmes.py` — ran clean
- `python scripts/generate_readmes.py --check` — "Catalog is valid and generated pages are current."