### PR TITLE
catalog: add dsh-self-evolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-evolve](https://github.com/william-jin-cmu/dsh-evolve) — Lets the agent write, hot-mount, and reversibly remove its own cordis plugins mid-session, growing new tools, prompt rules, and event hooks that persist across restarts.
 
+- [dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) — Evidence-first, crash-resumable self-evolution engine: bounded Cordis candidate generation, one-shot real-Loader admission, Harbor evaluation, and an auditable journaled lineage.
+
 - [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) — Expose DeepSeek Harness agent capabilities as an MCP server, letting any MCP client (e.g. Hermes) drive Harness to execute coding tasks.
 
 - [dsh-loop](https://github.com/vlln/dsh-loop) — Adds scheduled loops through a /loop command, a loop tool, and an activity status bar.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -400,6 +400,15 @@
       }
     },
     {
+      "name": "dsh-self-evolving",
+      "url": "https://github.com/timwhitez/dsh-self-evolving",
+      "category": "agent-automation",
+      "description": {
+        "en": "Evidence-first, crash-resumable self-evolution engine: bounded Cordis candidate generation, one-shot real-Loader admission, Harbor evaluation, and an auditable journaled lineage.",
+        "zh-CN": "证据优先、可崩溃恢复的自进化引擎：有界 Cordis 候选生成、一次性真实 Loader 准入、Harbor 评估，以及可审计的日志化谱系。"
+      }
+    },
+    {
       "name": "dsh-companion",
       "url": "https://github.com/william-jin-cmu/dsh-companion",
       "category": "productivity-collaboration",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -154,6 +154,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — 一个节省 token 的 DeepSeek Harness 智能体预设，将深度思考任务委派给专家子智能体。
 
+- [dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) — 证据优先、可崩溃恢复的自进化引擎：有界 Cordis 候选生成、一次性真实 Loader 准入、Harbor 评估，以及可审计的日志化谱系。
+
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — 面向结构化 Harness 循环工程的技能驱动工作流智能体 Plugin。
 
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — 由 Cordis 服务键支持的共享多智能体任务板。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category (agent-automation).
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

[dsh-self-evolving](https://github.com/timwhitez/dsh-self-evolving) is a standard DSH Cordis controller/service: bounded candidate generation, one-shot real-Loader admission, Harbor evaluation, auditable journaled lineage. The repo carries the `dsh-plugin` and `dsh` topics and publishes `@dsh-self-evolving/core` on npm. 291 unit + 36 real-Loader E2E tests; no Terminal-Bench improvement claim.