### PR TITLE
docs: add sjh9714/dsh-what-changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) — Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi — the model decides when and what to compress.
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) — Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
+- [dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) — Session-wide file change review in the session header. Lists every file the agent wrote this session with its hunks, counts refused writes separately from changes, and folds from a session projection rather than the on-disk log.
 
 - [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) — An ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while sharing DSH credentials and sessions.
 


### PR DESCRIPTION
Adds `dsh-what-changed` to Sessions & Storage in both language versions.

Per-call diff cards already render, so what is missing is the session-wide answer you want before committing, which files ended up changed. It puts a button in the session header with the file and edit counts and opens to a per-file review.

It registers a unit with `ctx.sessionProjections`. No core file is modified, no on-disk log is parsed, no events are subscribed to.

A write the permission fence refused is counted against its file and kept out of the edit total, since showing a refusal as a change recreates the problem the plugin exists to remove. A `tool/result` carrying the hunk the tool actually applied is preferred over the call arguments, and each edit records which of the two it came from.

Published on npm and verified in a live `dsh web` session against a real model. CI runs typecheck, tests and the build on Linux, macOS and Windows.

- Repo https://github.com/sjh9714/dsh-what-changed
- npm https://www.npmjs.com/package/dsh-what-changed
