### PR TITLE
Add DSH-CODEX-SUBSCRIPTION-POOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) — An ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while sharing DSH credentials and sessions.
 
+- [DSH-CODEX-SUBSCRIPTION-POOL](https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL) — Pool multiple ChatGPT/Codex subscriptions together. Image Generation and Websearch support.
+
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — A send_artifact tool that validates model-produced files and delivers structured descriptors through the standard dsh event stream for any client to render.
 
 - [dsh-bash-encoding](https://github.com/lhh010/dsh-bash-encoding) — Automatically detects and decodes Bash output encodings including UTF-16LE, UTF-8, and GBK for Windows and WSL.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) — An ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while sharing DSH credentials and sessions.
 
-- [DSH-CODEX-SUBSCRIPTION-POOL](https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL) — Pool multiple ChatGPT/Codex subscriptions together. Image Generation and Websearch support.
+- [DSH-CODEX-SUBSCRIPTION-POOL](https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL) — Use your ChatGPT/Codex subscriptions in DSH, with image generation and web search support.
 
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — A send_artifact tool that validates model-produced files and delivers structured descriptors through the standard dsh event stream for any client to render.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -778,8 +778,8 @@
       "url": "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL",
       "category": "developer-tools",
       "description": {
-        "en": "Pool multiple ChatGPT/Codex subscriptions together. Image Generation and Websearch support.",
-        "zh-CN": "集中管理多个 ChatGPT/Codex 订阅，并支持图像生成和 Web 搜索。"
+        "en": "Use your ChatGPT/Codex subscriptions in DSH, with image generation and web search support.",
+        "zh-CN": "在 DSH 中使用你的 ChatGPT/Codex 订阅，并支持图像生成和 Web 搜索。"
       }
     }
   ]

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,15 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "DSH-CODEX-SUBSCRIPTION-POOL",
+      "url": "https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL",
+      "category": "developer-tools",
+      "description": {
+        "en": "Pool multiple ChatGPT/Codex subscriptions together. Image Generation and Websearch support.",
+        "zh-CN": "集中管理多个 ChatGPT/Codex 订阅，并支持图像生成和 Web 搜索。"
+      }
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -58,6 +58,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 将编码智能体的对话历史导入为可恢复的 DeepSeek Harness 会话，并支持导出和同步到 Claude Code。
 
+- [DSH-CODEX-SUBSCRIPTION-POOL](https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL) — 集中管理多个 ChatGPT/Codex 订阅，并支持图像生成和 Web 搜索。
+
 - [dsh-custom-tool](https://github.com/FSMargoo/dsh-custom-tool) — 通过 Monaco 编辑器及模型驱动的生命周期创建和管理沙箱化 JavaScript 工具。
 
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — 将 Git 提交作者身份固定为当前环境身份，并优先使用已登录的 GitHub CLI 账号。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -58,7 +58,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) — 将编码智能体的对话历史导入为可恢复的 DeepSeek Harness 会话，并支持导出和同步到 Claude Code。
 
-- [DSH-CODEX-SUBSCRIPTION-POOL](https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL) — 集中管理多个 ChatGPT/Codex 订阅，并支持图像生成和 Web 搜索。
+- [DSH-CODEX-SUBSCRIPTION-POOL](https://github.com/Eve-146T/DSH-CODEX-SUBSCRIPTION-POOL) — 在 DSH 中使用你的 ChatGPT/Codex 订阅，并支持图像生成和 Web 搜索。
 
 - [dsh-custom-tool](https://github.com/FSMargoo/dsh-custom-tool) — 通过 Monaco 编辑器及模型驱动的生命周期创建和管理沙箱化 JavaScript 工具。
 


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

Adds `DSH-CODEX-SUBSCRIPTION-POOL` under **Developer tools**.

Use your ChatGPT/Codex subscriptions in DSH, with image generation and web search support.
