### PR TITLE
Add dsh-memory-porter (Data, research & knowledge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — Adds long-term cross-session memory with Git-branch awareness and background skill evolution.
 
+- [dsh-memory-porter](https://github.com/Shiye-10Pages/dsh-memory-porter) — Brings existing Claude and ChatGPT history into DSH, with verbatim evidence checked against the source by code before anything is stored.
+
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) — Cross-session memory for DeepSeek Harness: SQLite + human-editable Markdown mirror, autoDream consolidation, six memory tools, and fully-offline semantic search (local embedding / rerank / clustering), 198 tests.
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon-powered local memory system with three-tier storage (runtime hot memory, project Documents, and long-term Memory Spaces), supervised writeback, retrieval tools, and a Web UI.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -85,6 +85,15 @@
       }
     },
     {
+      "name": "dsh-memory-porter",
+      "url": "https://github.com/Shiye-10Pages/dsh-memory-porter",
+      "category": "data-research-knowledge",
+      "description": {
+        "en": "Brings existing Claude and ChatGPT history into DSH, with verbatim evidence checked against the source by code before anything is stored.",
+        "zh-CN": "把已有的 Claude 与 ChatGPT 历史搬进 DSH，入库前每条记忆的逐字证据都由代码回原文核对。"
+      }
+    },
+    {
       "name": "mstar-harness",
       "url": "https://github.com/btspoony/mstar-harness",
       "category": "agent-automation",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -188,6 +188,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) — 提供带 Git 分支感知和后台技能进化能力的跨会话长期记忆。
 
+- [dsh-memory-porter](https://github.com/Shiye-10Pages/dsh-memory-porter) — 把已有的 Claude 与 ChatGPT 历史搬进 DSH，入库前每条记忆的逐字证据都由代码回原文核对。
+
 - [dsh-mneme](https://github.com/modusensus/dsh-mneme) — 面向 DeepSeek Harness 的跨会话记忆插件：SQLite + 可人工编辑的 Markdown 双写，autoDream 后台巩固，6 个记忆工具，完全离线语义检索（本地向量 / 精排 / 聚类），198 个测试。
 
 - [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) — Mnemon 驱动的本地记忆系统：三层存储（运行时热记忆、项目档案 Documents、长期记忆体 Memory Spaces），受监督写回、检索工具与 Web UI。


### PR DESCRIPTION
Adds one entry under **Data, research & knowledge**, following the documented flow:

- English entry added to `README.md` in alphabetical position
- Bilingual metadata added to `catalog/plugins.json` (single entry, surrounding formatting untouched)
- Simplified Chinese mirror regenerated with `python scripts/generate_readmes.py` — reports *Catalog is valid and generated pages are current*

**What it is**: it brings a user's existing Claude / ChatGPT history into DSH. Three paths — the `memories.json` inside a Claude account export (already distilled, so zero tokens), local Claude Code transcripts with no export needed, and conversations distilled through whichever model the user already configured in DSH, so no extra API key is required.

**Why it belongs in this category rather than memory**: the work is retrieval and provenance over existing knowledge, not runtime memory for the agent. Evidence for every entry is verified against the source text by code rather than accepted on the model's word — in a real run over a 7-conversation export, 6 of 25 candidates were dropped for failing that check.

MIT, published on npm as `dsh-memory-porter`, zero runtime dependencies, public repo with the `dsh-plugin` topic and a description set.