### PR TITLE
Add TokenLedger

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 ### Cloud, DevOps & observability
 
 - [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) — Operations toolkit with A/B snapshot upgrades, automatic recovery, rollback, and a diagnostic self-healing command.
+- [TokenLedger](https://github.com/zh667/TokenLedger) — Shows local DSH token usage by relay site, project, and model, with account balances and subscription quota windows.
 
 ### AI, design & media
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -184,6 +184,15 @@
       }
     },
     {
+      "name": "TokenLedger",
+      "url": "https://github.com/zh667/TokenLedger",
+      "category": "cloud-devops-observability",
+      "description": {
+        "en": "Shows local DSH token usage by relay site, project, and model, with account balances and subscription quota windows.",
+        "zh-CN": "按中转站点、项目和模型统计本地 DSH Token 用量，并显示账户余额与订阅额度周期。"
+      }
+    },
+    {
       "name": "plugin-registry",
       "url": "https://github.com/vlln/plugin-registry",
       "category": "developer-tools",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -202,6 +202,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) — 运维工具箱，提供 A/B 快照升级、自动恢复、回滚和诊断式自愈命令。
 
+- [TokenLedger](https://github.com/zh667/TokenLedger) — 按中转站点、项目和模型统计本地 DSH Token 用量，并显示账户余额与订阅额度周期。
+
 ### AI、设计与媒体
 
 - [DSH OpenPencil](https://github.com/ZSeven-W/dsh-openpencil) — 连接 DeepSeek Harness 与 OpenPencil，让智能体创建、编辑、预览和验证可交互的多页面设计画布。


### PR DESCRIPTION
Adds TokenLedger to the Cloud, DevOps and observability section, with matching English and Simplified Chinese catalog metadata. Validation: python scripts/generate_readmes.py --check.