### PR TITLE
Add dsh-movein to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — Pins Git commit authorship to the active environment identity, prioritizing the signed-in GitHub CLI account.
 
+- [dsh-movein](https://github.com/sjh9714/dsh-movein) — Migrates a whole Claude Code or Codex CLI setup into DeepSeek Harness in one command, covering skills, slash commands, MCP servers, hooks, subagents and permission rules, with a dry-run estimate first.
+
 - [dsh-open-in-vscode](https://github.com/FSMargoo/dsh-open-in-vscode) — Open DeepSeek Harness workspace directories in VS Code from the web interface.
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-git-identity](https://github.com/LoserFox/dsh-git-identity) — Pins Git commit authorship to the active environment identity, prioritizing the signed-in GitHub CLI account.
 
-- [dsh-movein](https://github.com/sjh9714/dsh-movein) — Migrates a whole Claude Code or Codex CLI setup into DeepSeek Harness in one command, covering skills, slash commands, MCP servers, hooks, subagents and permission rules, with a dry-run estimate first.
+- [dsh-movein](https://github.com/sjh9714/dsh-movein) - Moves Claude Code, Codex CLI or OpenCode setup into DeepSeek Harness, converting supported skills, commands, agents, MCP servers, hooks and permission rules after a dry run.
 
 - [dsh-open-in-vscode](https://github.com/FSMargoo/dsh-open-in-vscode) — Open DeepSeek Harness workspace directories in VS Code from the web interface.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -107,8 +107,8 @@
       "url": "https://github.com/sjh9714/dsh-movein",
       "category": "developer-tools",
       "description": {
-        "en": "Migrates a whole Claude Code or Codex CLI setup into DeepSeek Harness in one command, covering skills, slash commands, MCP servers, hooks, subagents and permission rules, with a dry-run estimate first.",
-        "zh-CN": "一条命令把整套 Claude Code 或 Codex CLI 配置迁入 DeepSeek Harness，涵盖技能、斜杠命令、MCP 服务器、hooks、子代理与权限规则，默认先出预演清单。"
+        "en": "Moves Claude Code, Codex CLI or OpenCode setup into DeepSeek Harness, converting supported skills, commands, agents, MCP servers, hooks and permission rules after a dry run.",
+        "zh-CN": "把 Claude Code、Codex CLI 或 OpenCode 配置迁入 DeepSeek Harness，预演后转换受支持的技能、命令、代理、MCP 服务器、hooks 与权限规则。"
       }
     },
     {

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -103,6 +103,15 @@
       }
     },
     {
+      "name": "dsh-movein",
+      "url": "https://github.com/sjh9714/dsh-movein",
+      "category": "developer-tools",
+      "description": {
+        "en": "Migrates a whole Claude Code or Codex CLI setup into DeepSeek Harness in one command, covering skills, slash commands, MCP servers, hooks, subagents and permission rules, with a dry-run estimate first.",
+        "zh-CN": "一条命令把整套 Claude Code 或 Codex CLI 配置迁入 DeepSeek Harness，涵盖技能、斜杠命令、MCP 服务器、hooks、子代理与权限规则，默认先出预演清单。"
+      }
+    },
+    {
       "name": "dsh-open-in-vscode",
       "url": "https://github.com/FSMargoo/dsh-open-in-vscode",
       "category": "developer-tools",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -64,6 +64,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 一个将令牌同步到 gh CLI 配置的可视化 GitHub 设备码登录工具。
 
+- [dsh-movein](https://github.com/sjh9714/dsh-movein) — 一条命令把整套 Claude Code 或 Codex CLI 配置迁入 DeepSeek Harness，涵盖技能、斜杠命令、MCP 服务器、hooks、子代理与权限规则，默认先出预演清单。
+
 - [dsh-open-in-vscode](https://github.com/FSMargoo/dsh-open-in-vscode) — 可从 DeepSeek Harness Web 界面直接在 VS Code 中打开工作区目录。
 
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) — DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -64,7 +64,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — 一个将令牌同步到 gh CLI 配置的可视化 GitHub 设备码登录工具。
 
-- [dsh-movein](https://github.com/sjh9714/dsh-movein) — 一条命令把整套 Claude Code 或 Codex CLI 配置迁入 DeepSeek Harness，涵盖技能、斜杠命令、MCP 服务器、hooks、子代理与权限规则，默认先出预演清单。
+- [dsh-movein](https://github.com/sjh9714/dsh-movein) — 把 Claude Code、Codex CLI 或 OpenCode 配置迁入 DeepSeek Harness，预演后转换受支持的技能、命令、代理、MCP 服务器、hooks 与权限规则。
 
 - [dsh-open-in-vscode](https://github.com/FSMargoo/dsh-open-in-vscode) — 可从 DeepSeek Harness Web 界面直接在 VS Code 中打开工作区目录。
 


### PR DESCRIPTION
Adds dsh-movein under Developer tools with bilingual catalog metadata and a regenerated Simplified Chinese mirror.

dsh-movein moves Claude Code, Codex CLI or OpenCode setup into DSH. It converts supported skills, commands, agents, MCP servers, hooks and permission rules after a dry run.

`python scripts/generate_readmes.py --check` passes.

The project is not listed here under another name or URL.
