### PR TITLE
docs: add odai-dsh-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation that routes irreversible operations to human approval.
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.
+- [odai-dsh-plugin](https://github.com/orziz/odai/tree/main/dsh/plugin) — A profile-wide DSH governance and routing bundle with scoped local semantic memory and configurable compaction calls, compatible with DSH 0.1.0-rc.6 and 0.1.0-rc.7.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — A shared multi-agent task board backed by a Cordis service key.
 
 ### Productivity & collaboration

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,15 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "odai-dsh-plugin",
+      "url": "https://github.com/orziz/odai/tree/main/dsh/plugin",
+      "category": "agent-automation",
+      "description": {
+        "en": "A profile-wide DSH governance and routing bundle with scoped local semantic memory and configurable compaction calls, compatible with DSH 0.1.0-rc.6 and 0.1.0-rc.7.",
+        "zh-CN": "面向整个 DSH profile 的治理与路由 bundle，提供本地作用域语义记忆与可配置的压缩调用；兼容 DSH 0.1.0-rc.6 与 0.1.0-rc.7。"
+      }
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -156,6 +156,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — 面向结构化 Harness 循环工程的技能驱动工作流智能体 Plugin。
 
+- [odai-dsh-plugin](https://github.com/orziz/odai/tree/main/dsh/plugin) — 面向整个 DSH profile 的治理与路由 bundle，提供本地作用域语义记忆与可配置的压缩调用；兼容 DSH 0.1.0-rc.6 与 0.1.0-rc.7。
+
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — 由 Cordis 服务键支持的共享多智能体任务板。
 
 ### 效率与协作


### PR DESCRIPTION
## Summary

- Add `odai-dsh-plugin` to Agent orchestration & automation, its JSON catalog, and the generated Chinese index.
- Describe the profile-wide governance and routing surface, including the Web Control Center for responsibility and evidence inspection, compaction, scoped semantic memory, safety continuity, and verified delivery.
- Record the published package contract: `odai-dsh-plugin@0.2.29` supports exactly `@deepseek-ai/dsh@0.1.5-rc.1`.

Disclosure: I maintain Odai.

## Validation

- `python scripts/generate_readmes.py`
- `python scripts/generate_readmes.py --check`
- `git diff --check`
- npm registry verified the exact peer contract; the registry record provides no `gitHead`, and the published tarball contains canonical Odai `0.3.11`, runtime contract `6`, and the Web client export