### PR TITLE
Add dsh-sentinel: plugin security scanner for DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.
 
+- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel) — Static security scanner for DeepSeek Harness plugins: zero-dependency read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.
+
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — A DeepSeek Harness Cordis plugin that routes an 85-skill pack for reverse engineering and authorized security research.
 
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.
 
-- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel) — Static security scanner for DeepSeek Harness plugins: zero-dependency read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.
+- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel-scanner) — Static security scanner for DeepSeek Harness plugins: zero-dependency read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.
 
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — A DeepSeek Harness Cordis plugin that routes an 85-skill pack for reverse engineering and authorized security research.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — Transparent rankings and recommendations for the DSH plugin ecosystem: daily auto-fetched topic data, an open scoring model, and rank/search/recommend tools with a settings-page leaderboard.
 
-- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel-scanner) — Static security scanner for DeepSeek Harness plugins: zero-dependency read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.
+- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel-scanner) — Static security scanner for DeepSeek Harness plugins: read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.
 
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — A DeepSeek Harness Cordis plugin that routes an 85-skill pack for reverse engineering and authorized security research.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -581,11 +581,11 @@
     },
     {
       "name": "dsh-sentinel",
-      "url": "https://github.com/Eligahyu/dsh-sentinel",
+      "url": "https://github.com/Eligahyu/dsh-sentinel-scanner",
       "category": "developer-tools",
       "description": {
-        "en": "Static security scanner for DeepSeek Harness plugins: zero-dependency read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.",
-        "zh-CN": "DeepSeek Harness 插件安全扫描器：零依赖只读静态审计（代码执行、凭据访问、外传、混淆、安装脚本、bundle 清单合规），输出 0-100 风险分；既是 DSH 工具插件，也是独立 CLI。"
+        "en": "Static security scanner for DeepSeek Harness plugins: read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.",
+        "zh-CN": "DeepSeek Harness 插件安全扫描器：只读静态审计（代码执行、凭据访问、外传、混淆、安装脚本、bundle 清单合规），输出 0-100 风险分；既是 DSH 工具插件，也是独立 CLI。"
       }
     },
     {

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -580,6 +580,15 @@
       }
     },
     {
+      "name": "dsh-sentinel",
+      "url": "https://github.com/Eligahyu/dsh-sentinel",
+      "category": "developer-tools",
+      "description": {
+        "en": "Static security scanner for DeepSeek Harness plugins: zero-dependency read-only audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance) with a 0-100 risk score; works as a DSH tool plugin and a standalone CLI.",
+        "zh-CN": "DeepSeek Harness 插件安全扫描器：零依赖只读静态审计（代码执行、凭据访问、外传、混淆、安装脚本、bundle 清单合规），输出 0-100 风险分；既是 DSH 工具插件，也是独立 CLI。"
+      }
+    },
+    {
       "name": "dsh-skin",
       "url": "https://github.com/KinGao294/dsh-skin",
       "category": "ui-user-experience",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -70,7 +70,7 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — DSH 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
 
-- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel) — DeepSeek Harness 插件安全扫描器：零依赖只读静态审计（代码执行、凭据访问、外传、混淆、安装脚本、bundle 清单合规），输出 0-100 风险分；既是 DSH 工具插件，也是独立 CLI。
+- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel-scanner) — DeepSeek Harness 插件安全扫描器：只读静态审计（代码执行、凭据访问、外传、混淆、安装脚本、bundle 清单合规），输出 0-100 风险分；既是 DSH 工具插件，也是独立 CLI。
 
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — DeepSeek Harness 高级设置管理器，支持表单级和文件级配置编辑及插件设置 SDK。
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -70,6 +70,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) — DSH 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
 
+- [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel) — DeepSeek Harness 插件安全扫描器：零依赖只读静态审计（代码执行、凭据访问、外传、混淆、安装脚本、bundle 清单合规），输出 0-100 风险分；既是 DSH 工具插件，也是独立 CLI。
+
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — DeepSeek Harness 高级设置管理器，支持表单级和文件级配置编辑及插件设置 SDK。
 
 - [dsh-spend](https://github.com/nonewind/dsh-spend) — DSH Web 的用量与预计花费统计，支持按模型、日期和会话查看。


### PR DESCRIPTION
Add [dsh-sentinel](https://github.com/Eligahyu/dsh-sentinel) to the Developer tools category.

A static security scanner for DeepSeek Harness plugins:
- zero-dependency, read-only static audit (code execution, credential access, exfiltration, obfuscation, install scripts, bundle manifest compliance)
- 0-100 risk score with verdicts; SARIF / HTML / JSON reports
- pre-install package audit (tarball integrity, safe extraction) and source-vs-package diff
- works both as a DSH tool plugin (sentinel_scan / sentinel_scan_profile / sentinel_audit_package) and a standalone CLI
- published on npm as deepseek-harness-sentinel