### PR TITLE
Add DSH Plugin Store to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-github-login](https://github.com/Noob-stupid/dsh-github-login) — A visual GitHub device-flow login tool that syncs its token into gh CLI config.
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — A living DeepSeek Harness plugin directory with a compatibility CI, searchable catalog, and in-app plugin store.
+- [DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) — Native DSH Settings marketplace with Community and Installed views, catalog search and tag filters, plus provenance-gated local Profile installation for runtime-verified npm plugins.
 - [create-dsh-plugin](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin) — A DSH plugin scaffolder with templates and a built-in smoke test.
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — An in-app DSH Web UI plugin store with browsing, search, installation, compatibility badges, and an installed list.
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — Advanced form- and file-level settings management with a plugin settings registration SDK.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -708,6 +708,14 @@
       "description": {"en": "A living DeepSeek Harness plugin directory with compatibility CI, a searchable catalog, and an in-app plugin store.", "zh-CN": "DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。"}
     },
     {
+      "name": "DSH Plugin Store",
+      "url": "https://github.com/sandbaseai/dsh-plugin-store",
+      "category": "developer-tools",
+      "description": {"en": "Native DSH Settings marketplace with Community and Installed views, catalog search and tag filters, plus provenance-gated local Profile installation for runtime-verified npm plugins.", "zh-CN": "DSH Settings 原生插件市场，提供社区与已安装视图、目录搜索和标签筛选，并仅为运行时已验证的 npm 插件执行来源准入受控的本地 Profile 安装。"},
+      "status": "beta",
+      "source": "community"
+    },
+    {
       "name": "create-dsh-plugin",
       "url": "https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin",
       "category": "developer-tools",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -48,6 +48,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dhicoc/dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) — 一个为逆向工程和经授权安全研究路由 85 项技能包的 DeepSeek Harness Cordis 插件。
 
+- [DSH Plugin Store](https://github.com/sandbaseai/dsh-plugin-store) — DSH Settings 原生插件市场，提供社区与已安装视图、目录搜索和标签筛选，并仅为运行时已验证的 npm 插件执行来源准入受控的本地 Profile 安装。 (beta)
+
 - [dsh-artifact](https://github.com/william-jin-cmu/dsh-artifact) — 提供 send_artifact 工具，校验模型产出的文件并通过 dsh 标准事件流交付结构化描述子，任何客户端都可按需呈现。
 
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) — 在 DSH Web 输入框下方实时显示 DeepSeek 账户余额与本场会话花费，自动抓取官方价格并支持峰谷计价。


### PR DESCRIPTION
## Summary

- add DSH Plugin Store to Developer tools
- add matching English and Simplified Chinese catalog metadata
- regenerate and validate the Simplified Chinese mirror

## Listing evidence

- Native DeepSeek Harness Settings bundle with Community and Installed views
- Catalog search, tag filtering, sorting, and local Profile installation
- Canonical source: https://github.com/sandbaseai/dsh-plugin-store
- MIT licensed; current release is 0.1.0-preview.5
- Public DSH 0.1.0-rc.8 runtime smoke test is documented in the repository
- Preview 5 limits installation to matching verified / runtime_verified catalog records and a single npm package spec

## Validation

- python3 scripts/generate_readmes.py
- python3 scripts/generate_readmes.py --check
- git diff --check

## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category: developer-tools.
- [x] I ran python scripts/generate_readmes.py --check successfully.

Disclosure: I am contributing on behalf of SandbaseAI, which maintains the linked project.
