### PR TITLE
Add dsh-wrapped to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — An in-app DSH Web UI plugin store with browsing, search, installation, compatibility badges, and an installed list.
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — Advanced form- and file-level settings management with a plugin settings registration SDK.
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) — An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.
+- [dsh-wrapped](https://github.com/rand0wn/dsh-wrapped) — Generates a shareable dark SVG summary card from a session's own stats: tool vs. thinking time, decode speed, and a tool/thinking-ratio verdict, via a `/wrapped` command.
 
 ### UI & user experience
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,12 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "dsh-wrapped",
+      "url": "https://github.com/rand0wn/dsh-wrapped",
+      "category": "developer-tools",
+      "description": {"en": "Generates a shareable dark SVG summary card from a session's own stats: tool vs. thinking time, decode speed, and a tool/thinking-ratio verdict, via a /wrapped command.", "zh-CN": "通过 /wrapped 命令，用会话自身的统计数据生成可分享的深色 SVG 摘要卡片：工具耗时与思考耗时对比、解码速度，以及基于两者比例得出的一句话结论。"}
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -76,6 +76,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。
 
+- [dsh-wrapped](https://github.com/rand0wn/dsh-wrapped) — 通过 /wrapped 命令，用会话自身的统计数据生成可分享的深色 SVG 摘要卡片：工具耗时与思考耗时对比、解码速度，以及基于两者比例得出的一句话结论。
+
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店，支持浏览、搜索、安装、兼容徽章和已装列表。
 
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 基于浏览器的 Plugin 管理控制台，并提供官方 DSH Plugin 开发引导。


### PR DESCRIPTION
Adds `dsh-wrapped` — registers `/wrapped`, which reads the current session's `sessionStats` projection and renders a shareable dark SVG summary card (tool time vs. thinking time, decode speed, and a tool/thinking-ratio verdict).

- Declares `dsh.bundle` in `package.json`, installable via `dsh plugin add`.
- MIT licensed, TypeScript, 11 passing unit tests, CI wired.
- Verified against a real local `dsh web` boot with Playwright: ran a real multi-tool-call turn, invoked `/wrapped`, and confirmed the written SVG's numbers matched the session's own stats strip.

Repo: https://github.com/rand0wn/dsh-wrapped

Ran `python scripts/generate_readmes.py` and `--check` per CONTRIBUTING.md; both pass.