### PR TITLE
Add Renzic-Stone/DSH-EasyRewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 
 - [dsh-cc-tui](https://github.com/ccch1mneyyy/dsh-cc-tui) — A Claude Code-style full-screen terminal interface with streaming thought display, rollback controls, and context/TPS indicators.
 
+- [dsh-easyrewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — Inline edit and recall for user message bubbles in the DSH Web UI, with lazy commit, seamless in-place replacement, a version pager, draft auto-backup, and trilingual i18n.
+
 - [dsh-genui](https://github.com/omdsh-dev/dsh-genui) — Renders interactive UI components inline in assistant replies, including charts, forms, quizzes, Mermaid diagrams, 3D scenes, and model action events.
 
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) — Use dsh via grok-build's tui.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -166,6 +166,15 @@
       }
     },
     {
+      "name": "dsh-easyrewrite",
+      "url": "https://github.com/Renzic-Stone/DSH-EasyRewrite",
+      "category": "ui-user-experience",
+      "description": {
+        "en": "Inline edit and recall for user message bubbles in the DSH Web UI, with lazy commit, seamless in-place replacement, a version pager, draft auto-backup, and trilingual i18n.",
+        "zh-CN": "在 DSH Web 界面中提供用户消息气泡的内联编辑与撤回，支持惰性提交、无痕替换、版本翻页器、草稿自动备份与三语 i18n。"
+      }
+    },
+    {
       "name": "dsh-harness-ops",
       "url": "https://github.com/fakechris/dsh-harness-ops",
       "category": "cloud-devops-observability",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -98,6 +98,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-desktop](https://github.com/howlma/dsh-desktop) — Windows 桌面客户端：打开即拉起或复用 Harness 网关，窗口内嵌官方 Web 界面；托盘常驻，可选开机自启。
 
+- [dsh-easyrewrite](https://github.com/Renzic-Stone/DSH-EasyRewrite) — 在 DSH Web 界面中提供用户消息气泡的内联编辑与撤回，支持惰性提交、无痕替换、版本翻页器、草稿自动备份与三语 i18n。
+
 - [dsh-genui](https://github.com/omdsh-dev/dsh-genui) — 在助手回复中内联渲染可交互 UI 组件，支持图表、表单、测验、Mermaid 图、3D 场景和模型动作事件。
 
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) — 借用grok-build tui使用dsh


### PR DESCRIPTION
Add dsh-easyrewrite — bubble inline edit & recall for DSH Web. npm: dsh-easyrewrite, manifest verified.

## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

- Category: **UI & user experience** (matching the existing catalog taxonomy).
- Repo: https://github.com/Renzic-Stone/DSH-EasyRewrite (MIT, topics: dsh-plugin / dsh / deepseek-harness / rewrite / undo / i18n)
- npm: `dsh-easyrewrite@1.3.5` — declares `dsh.bundle.patch` + `cordis.patch.yml`, installable via `dsh plugin add`.
- Also listed in the official awesome-dsh-plugin (session category).