### PR TITLE
docs: add Tabbit-Browser/dsh-plugin (tabbit-browser)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [mstar-harness](https://github.com/btspoony/mstar-harness) — A skill-driven workflow agent plugin for structured harness-loop engineering.
 
 - [dsh-approval-gate](https://github.com/moon09300731/dsh-approval-gate) — Risk-gated approval automation that routes irreversible operations to human approval.
+- [tabbit-browser](https://github.com/Tabbit-Browser/dsh-plugin) — Gives the DeepSeek Harness agent control of a real Tabbit Browser through `tabbit-cli` for web automation, information extraction, QA, and benchmarks, with a bundled skill and a region-aware installer tool.
 - [dsh-preset-flash-director](https://github.com/zhaoyilun/dsh-preset-flash-director) — A token-economical DSH agent preset that delegates deep reasoning to expert subagents.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — A shared multi-agent task board backed by a Cordis service key.
 

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,15 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
+    },
+    {
+      "name": "tabbit-browser",
+      "url": "https://github.com/Tabbit-Browser/dsh-plugin",
+      "category": "agent-automation",
+      "description": {
+        "en": "Gives the DeepSeek Harness agent control of a real Tabbit Browser through tabbit-cli for web automation, information extraction, QA, and benchmarks, with a bundled skill and a region-aware installer tool.",
+        "zh-CN": "通过 tabbit-cli 让 DeepSeek Harness 智能体驱动真实的 Tabbit 浏览器，用于网页自动化、信息抽取、QA 与基准测试，内置技能并提供按地区分发的安装器工具。"
+      }
     }
   ]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -158,6 +158,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) — 由 Cordis 服务键支持的共享多智能体任务板。
 
+- [tabbit-browser](https://github.com/Tabbit-Browser/dsh-plugin) — 通过 tabbit-cli 让 DeepSeek Harness 智能体驱动真实的 Tabbit 浏览器，用于网页自动化、信息抽取、QA 与基准测试，内置技能并提供按地区分发的安装器工具。
+
 ### 效率与协作
 
 - [deepseek-manners](https://github.com/Moeblack/deepseek-manners) — 给每次助手回复追加一句感谢语。


### PR DESCRIPTION
Adds the tabbit-browser plugin to the Agent orchestration & automation category. It gives the DeepSeek Harness agent control of a real Tabbit Browser through tabbit-cli for web automation, information extraction, QA, and benchmarks, with a bundled skill and a region-aware installer tool.

Updates the English README by hand and adds matching bilingual metadata to catalog/plugins.json; the Simplified Chinese mirror is regenerated and validated via scripts/generate_readmes.py --check.

## Plugin submission checklist

- [ ] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [ ] I used the canonical public project URL.
- [ ] I added concise English and Simplified Chinese descriptions.
- [ ] I chose an existing category, or explained why a new bilingual category is necessary.
- [ ] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

<!-- Add any installation, maintenance, or categorization context reviewers should know. -->
