### PR TITLE
Add dsh-web-search-ddg to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ DeepSeek Harness plugins can connect an agent to tools, services, devices, and r
 - [dsh-settings-plus](https://github.com/oneinitAI/dsh-settings-plus) — Advanced form- and file-level settings management with a plugin settings registration SDK.
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) — An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.
 
+- [dsh-web-search-ddg](https://github.com/tatselkrik/dsh-web-search-ddg) — Keyless DuckDuckGo web search provider for the built-in web_search tool: zero API keys or tokens per search, strict-mode parsing with redirect unwrapping and dedupe, configurable GET/POST and request timeouts.
+
 ### UI & user experience
 
 - [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) — A Rust terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.

--- a/catalog/plugins.json
+++ b/catalog/plugins.json
@@ -772,6 +772,15 @@
       "url": "https://github.com/BeiZi6/dsh-opencodego-usage",
       "category": "developer-tools",
       "description": {"en": "An OpenCodeGo quota monitor for the DSH Web GUI with rolling, weekly, and monthly usage views.", "zh-CN": "DSH Web GUI 的 OpenCodeGo 额度监视器，提供滚动、周和月度用量视图。"}
-    }
-  ]
+    },
+      {
+            "name": "dsh-web-search-ddg",
+            "url": "https://github.com/tatselkrik/dsh-web-search-ddg",
+            "category": "developer-tools",
+            "description": {
+                  "en": "Keyless DuckDuckGo web search provider for the built-in web_search tool: zero API keys or tokens per search, strict-mode parsing with redirect unwrapping, dedupe, entity-safe text, configurable GET/POST and request timeouts.",
+                  "zh-CN": "为内置 web_search 工具提供免密钥的 DuckDuckGo 搜索：每次搜索零 API key、零 token；严格模式解析，支持重定向解包、URL 去重与实体安全文本，可配置 GET/POST 与请求超时。"
+            }
+      }
+]
 }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -76,6 +76,8 @@ DeepSeek Harness Plugin 能让智能体连接工具、服务、设备和可复�
 
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) — DSH 插件活目录，提供兼容性 CI、可搜索目录和内置插件商店。
 
+- [dsh-web-search-ddg](https://github.com/tatselkrik/dsh-web-search-ddg) — 为内置 web_search 工具提供免密钥的 DuckDuckGo 搜索：每次搜索零 API key、零 token；严格模式解析，支持重定向解包、URL 去重与实体安全文本，可配置 GET/POST 与请求超时。
+
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) — DSH Web UI 内置插件商店，支持浏览、搜索、安装、兼容徽章和已装列表。
 
 - [plugin-registry](https://github.com/vlln/plugin-registry) — 基于浏览器的 Plugin 管理控制台，并提供官方 DSH Plugin 开发引导。


### PR DESCRIPTION
## Plugin submission checklist

- [x] This is a DeepSeek Harness plugin or has documented DeepSeek Harness integration.
- [x] I used the canonical public project URL.
- [x] I added concise English and Simplified Chinese descriptions.
- [x] I chose an existing category, or explained why a new bilingual category is necessary.
- [x] I ran `python scripts/generate_readmes.py --check` successfully.

## Notes

Adds a keyless DuckDuckGo web search provider for DSH's built-in `web_search` tool.

- No API keys, accounts, or per-search tokens — scrapes lite.duckduckgo.com via `ctx.web`'s `WebSearchProvider` seam
- Strict mode: zero parsed results raise `WEB_PROVIDER_ERROR` instead of returning empty success
- uddg redirect unwrapping, internal-link filtering, URL dedupe, entity-safe decoding
- Configurable GET/POST form, result limit, and per-request timeout (15s default)
- Ships as an installable `dsh.bundle` with committed `lib/`, so `dsh plugin add github:tatselkrik/dsh-web-search-ddg` needs no build allowance
- CI-gated: typecheck + 19 unit tests green on GitHub Actions · MIT licensed

Category `developer-tools`; bilingual copy included in `catalog/plugins.json`; zh-CN mirror regenerated via the repo script.